### PR TITLE
Add support for ARRAY and ENUM in TypeMapper

### DIFF
--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -36,24 +36,29 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
   if (sequelizeType instanceof STRING ||
       sequelizeType instanceof TEXT ||
       sequelizeType instanceof UUID ||
-      sequelizeType instanceof DATE
-  ) return GraphQLString;
+      sequelizeType instanceof DATE) {
+        return GraphQLString
+      }
 
   if (sequelizeType instanceof ARRAY) {
     let elementType = toGraphQL(sequelizeType.type, sequelizeTypes);
-    return GraphQLList(elementType);
+    return new GraphQLList(elementType);
   }
 
   if (sequelizeType instanceof ENUM) {
     return new GraphQLEnumType({
-    values: sequelizeType.values.reduce((obj, value) => {
-      obj[value] = {value};
-      return obj;
-    }, {})});
+      values: sequelizeType.values.reduce((obj, value) => {
+        obj[value] = {value};
+        return obj;
+      }, {})
+    });
   }
 
   if (sequelizeType instanceof VIRTUAL) {
-    return toGraphQL(sequelizeType.returnType, sequelizeTypes);
+    let returnType = sequelizeType.returnType
+        ? toGraphQL(sequelizeType.returnType, sequelizeTypes)
+        : GraphQLString;
+    return returnType;
   }
 
   throw new Error(`Unable to convert ${sequelizeType.key || sequelizeType.toSql()} to a GraphQL type`);

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -1,26 +1,61 @@
-import { GraphQLInt, GraphQLString, GraphQLBoolean, GraphQLFloat } from 'graphql';
+import {
+  GraphQLInt,
+  GraphQLString,
+   GraphQLBoolean,
+   GraphQLFloat,
+   GraphQLEnumType,
+   GraphQLList
+ } from 'graphql';
 
+/**
+ * Checks the type of the sequelize data type and
+ * returns the corresponding type in GraphQL
+ * @param  {Object} sequelizeType
+ * @param  {Object} sequelizeTypes
+ * @return {Function} GraphQL type declaration
+ */
 export function toGraphQL(sequelizeType, sequelizeTypes) {
-  if (sequelizeType instanceof sequelizeTypes.BOOLEAN) {
-    return GraphQLBoolean;
-  } else if (sequelizeType instanceof sequelizeTypes.FLOAT) {
-    return GraphQLFloat;
-  } else if (sequelizeType instanceof sequelizeTypes.INTEGER) {
-    return GraphQLInt;
-  } else if (
-    sequelizeType instanceof sequelizeTypes.STRING ||
-    sequelizeType instanceof sequelizeTypes.TEXT ||
-    sequelizeType instanceof sequelizeTypes.UUID ||
-    sequelizeType instanceof sequelizeTypes.DATE
-  ) {
-    return GraphQLString;
-  } else if (sequelizeType instanceof sequelizeTypes.VIRTUAL) {
-    if (sequelizeType.returnType) {
-      return toGraphQL(sequelizeType.returnType, sequelizeTypes);
-    }
 
-    return GraphQLString;
-  } else {
-    throw new Error(`Unable to convert ${sequelizeType.key || sequelizeType.toSql()} to a GraphQL type`);
+  const {
+    BOOLEAN,
+    ENUM,
+    FLOAT,
+    INTEGER,
+    STRING,
+    TEXT,
+    UUID,
+    DATE,
+    ARRAY,
+    VIRTUAL
+  } = sequelizeTypes;
+
+  if (sequelizeType instanceof BOOLEAN) return GraphQLBoolean;
+  if (sequelizeType instanceof FLOAT) return GraphQLFloat;
+  if (sequelizeType instanceof INTEGER) return GraphQLInt;
+
+  if (sequelizeType instanceof STRING ||
+      sequelizeType instanceof TEXT ||
+      sequelizeType instanceof UUID ||
+      sequelizeType instanceof DATE
+  ) return GraphQLString;
+
+  if (sequelizeType instanceof ARRAY) {
+    let elementType = toGraphQL(sequelizeType.type, sequelizeTypes);
+    return GraphQLList(elementType);
   }
+
+  if (sequelizeType instanceof ENUM) {
+    return new GraphQLEnumType({
+    values: sequelizeType.values.reduce((obj, value) => {
+      obj[value] = {value};
+      return obj;
+    }, {})});
+  }
+
+  if (sequelizeType instanceof VIRTUAL) {
+    return toGraphQL(sequelizeType.returnType, sequelizeTypes);
+  }
+
+  throw new Error(`Unable to convert ${sequelizeType.key || sequelizeType.toSql()} to a GraphQL type`);
+
 }

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -37,8 +37,8 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
       sequelizeType instanceof TEXT ||
       sequelizeType instanceof UUID ||
       sequelizeType instanceof DATE) {
-        return GraphQLString
-      }
+    return GraphQLString;
+  }
 
   if (sequelizeType instanceof ARRAY) {
     let elementType = toGraphQL(sequelizeType.type, sequelizeTypes);

--- a/test/attributeFields.test.js
+++ b/test/attributeFields.test.js
@@ -12,7 +12,9 @@ import {
   GraphQLInt,
   GraphQLFloat,
   GraphQLNonNull,
-  GraphQLBoolean
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLList
 } from 'graphql';
 
 describe('attributeFields', function () {
@@ -30,6 +32,12 @@ describe('attributeFields', function () {
     float: {
       type: Sequelize.FLOAT
     },
+    enum: {
+      type: Sequelize.ENUM('first', 'second')
+    },
+    list: {
+      type: Sequelize.ARRAY(Sequelize.STRING)
+    },
     virtualInteger: {
       type: new Sequelize.VIRTUAL(Sequelize.INTEGER)
     },
@@ -43,7 +51,7 @@ describe('attributeFields', function () {
   it('should return fields for a simple model', function () {
     var fields = attributeFields(Model);
 
-    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName', 'lastName', 'float', 'virtualInteger', 'virtualBoolean']);
+    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName', 'lastName', 'float', 'enum', 'list', 'virtualInteger', 'virtualBoolean']);
 
     expect(fields.id.type).to.be.an.instanceOf(GraphQLNonNull);
     expect(fields.id.type.ofType).to.equal(GraphQLInt);
@@ -55,6 +63,10 @@ describe('attributeFields', function () {
 
     expect(fields.lastName.type).to.equal(GraphQLString);
 
+    expect(fields.enum.type).to.be.an.instanceOf(GraphQLEnumType);
+
+    expect(fields.list.type).to.be.an.instanceOf(GraphQLList);
+
     expect(fields.float.type).to.equal(GraphQLFloat);
 
     expect(fields.virtualInteger.type).to.equal(GraphQLInt);
@@ -64,7 +76,7 @@ describe('attributeFields', function () {
 
   it('should be possible to exclude fields', function () {
     var fields = attributeFields(Model, {
-      exclude: ['id', 'email', 'float', 'virtualInteger', 'virtualBoolean']
+      exclude: ['id', 'email', 'float', 'enum', 'list', 'virtualInteger', 'virtualBoolean']
     });
 
     expect(Object.keys(fields)).to.deep.equal(['firstName', 'lastName']);

--- a/test/typeMapper.test.js
+++ b/test/typeMapper.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import typeMapper from '../src/typeMapper';
+
+import {
+  BOOLEAN,
+  ENUM,
+  FLOAT,
+  INTEGER,
+  STRING
+} from 'sequelize';
+
+import {
+  GraphQLString,
+  GraphQLInt,
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLEnumType,
+  GraphQLList
+} from 'graphql';
+
+describe('typeMapper', () => {
+  // TODO write tests for typeMapper
+})


### PR DESCRIPTION
This should successfully translate `ARRAY` and `ENUM` sequelize types into the corresponding `GraphQLList` and `GraphQLEnumType`, respectively.

I also cleaned it up a little by using deconstructive assignment for `sequelizeTypes` and removing those `else` statements, since all `if` branches return the function when hit.