### PR TITLE
Add support for GraphQL Fragments

### DIFF
--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -1,5 +1,5 @@
 import * as typeMapper from './typeMapper';
-import { GraphQLNonNull } from 'graphql';
+import { GraphQLNonNull, GraphQLEnumType } from 'graphql';
 
 module.exports = function (Model, options) {
   options = options || {};
@@ -13,6 +13,10 @@ module.exports = function (Model, options) {
     memo[key] = {
       type: typeMapper.toGraphQL(type, Model.sequelize.constructor)
     };
+
+    if ( memo[key].type instanceof GraphQLEnumType ) {
+      memo[key].type.name = `${Model.name}${key}EnumType`;
+    }
 
     if (attribute.allowNull === false || attribute.primaryKey === true) {
       memo[key].type = new GraphQLNonNull(memo[key].type);

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -29,6 +29,9 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
     VIRTUAL
   } = sequelizeTypes;
 
+  // Regex for finding special characters
+  const specialChars = /[^a-z\d]/i;
+
   if (sequelizeType instanceof BOOLEAN) return GraphQLBoolean;
   if (sequelizeType instanceof FLOAT) return GraphQLFloat;
   if (sequelizeType instanceof INTEGER) return GraphQLInt;
@@ -48,6 +51,15 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
   if (sequelizeType instanceof ENUM) {
     return new GraphQLEnumType({
       values: sequelizeType.values.reduce((obj, value) => {
+        if (specialChars.test(value)) {
+          value = value.split(specialChars).reduce((reduced, val, idx) => {
+            let newVal = val;
+            if (idx > 0) {
+              newVal = `${val[0].toUpperCase()}${val.slice(1)}`;
+            }
+            return `${reduced}${newVal}`;
+          });
+        }
         obj[value] = {value};
         return obj;
       }, {})

--- a/test/attributeFields.test.js
+++ b/test/attributeFields.test.js
@@ -19,9 +19,9 @@ import {
 
 describe('attributeFields', function () {
   var Model;
-
+  var modelName = Math.random().toString();
   before(function () {
-    Model = sequelize.define(Math.random().toString(), {
+    Model = sequelize.define(modelName, {
       email: {
         type: Sequelize.STRING,
         allowNull: false
@@ -36,6 +36,9 @@ describe('attributeFields', function () {
         type: Sequelize.FLOAT
       },
       enum: {
+        type: Sequelize.ENUM('first', 'second')
+      },
+      enumTwo: {
         type: Sequelize.ENUM('first', 'second')
       },
       list: {
@@ -55,7 +58,7 @@ describe('attributeFields', function () {
   it('should return fields for a simple model', function () {
     var fields = attributeFields(Model);
 
-    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName', 'lastName', 'float', 'enum', 'list', 'virtualInteger', 'virtualBoolean']);
+    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName', 'lastName', 'float', 'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean']);
 
     expect(fields.id.type).to.be.an.instanceOf(GraphQLNonNull);
     expect(fields.id.type.ofType).to.equal(GraphQLInt);
@@ -69,6 +72,8 @@ describe('attributeFields', function () {
 
     expect(fields.enum.type).to.be.an.instanceOf(GraphQLEnumType);
 
+    expect(fields.enumTwo.type).to.be.an.instanceOf(GraphQLEnumType);
+
     expect(fields.list.type).to.be.an.instanceOf(GraphQLList);
 
     expect(fields.float.type).to.equal(GraphQLFloat);
@@ -80,9 +85,19 @@ describe('attributeFields', function () {
 
   it('should be possible to exclude fields', function () {
     var fields = attributeFields(Model, {
-      exclude: ['id', 'email', 'float', 'enum', 'list', 'virtualInteger', 'virtualBoolean']
+      exclude: ['id', 'email', 'float', 'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean']
     });
 
     expect(Object.keys(fields)).to.deep.equal(['firstName', 'lastName']);
+  });
+
+  it('should automatically name enum types', function () {
+    var fields = attributeFields(Model);
+
+    expect(fields.enum.type.name).to.not.be.undefined;
+    expect(fields.enumTwo.type.name).to.not.be.undefined;
+
+    expect(fields.enum.type.name).to.equal(modelName + 'enum' + 'EnumType');
+    expect(fields.enumTwo.type.name).to.equal(modelName + 'enumTwo' + 'EnumType');
   });
 });


### PR DESCRIPTION
As stated in #24 the simplifyAST function was failing on fragment queries. Adding support was easy as long as we have access to the info object which contains a fragments object containing all fragments on the query. Fixes #24