### PR TITLE
add support for unassociated GraphQL types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,6 @@ module.exports = {
   defaultArgs: require('./defaultArgs'),
   typeMapper: require('./typeMapper'),
   attributeFields: require('./attributeFields'),
-  simplifyAST: require('./simplifyAST')
+  simplifyAST: require('./simplifyAST'),
+  relay: require('./relay')
 };

--- a/src/relay.js
+++ b/src/relay.js
@@ -20,7 +20,6 @@ export function idFetcher(sequelize, nodeTypeMapper) {
   return globalId => {
     let {type, id} = fromGlobalId(globalId);
     const models = Object.keys(sequelize.models);
-    type = type.toLowerCase();
     if (models.some(model => model === type)) {
       return sequelize.models[type].findById(id);
     }
@@ -44,7 +43,7 @@ export function sequelizeNodeInterface(sequelize) {
   const nodeObjects = nodeDefinitions(idFetcher(sequelize, nodeTypeMapper), obj => {
     var name = obj.Model
             ? obj.Model.options.name.singular
-            : obj.name.toLowerCase();
+            : obj.name;
     return nodeTypeMapper[name];
   });
   return {

--- a/src/relay.js
+++ b/src/relay.js
@@ -44,7 +44,7 @@ export function sequelizeNodeInterface(sequelize) {
   const nodeObjects = nodeDefinitions(idFetcher(sequelize, nodeTypeMapper), obj => {
     var name = obj.Model
             ? obj.Model.options.name.singular
-            : obj.name;
+            : obj.name.toLowerCase();
     return nodeTypeMapper[name];
   });
   return {

--- a/test/relay.test.js
+++ b/test/relay.test.js
@@ -58,7 +58,7 @@ describe('relay', function () {
   before(function () {
     sequelize.modelManager.models = [];
     sequelize.models = {};
-    User = sequelize.define('user', {
+    User = sequelize.define('User', {
       name: {
         type: Sequelize.STRING
       }
@@ -66,7 +66,7 @@ describe('relay', function () {
       timestamps: false
     });
 
-    Task = sequelize.define('task', {
+    Task = sequelize.define('Task', {
       name: {
         type: Sequelize.STRING
       }
@@ -74,7 +74,7 @@ describe('relay', function () {
       timestamps: false
     });
 
-    Project = sequelize.define('project', {
+    Project = sequelize.define('Project', {
       name: {
         type: Sequelize.STRING
       }
@@ -150,11 +150,12 @@ describe('relay', function () {
       interfaces: [nodeInterface]
 });
 
+
     nodeTypeMapper.mapTypes({
       [User.name]: userType,
       [Project.name]: projectType,
       [Task.name]: taskType,
-      viewer: viewerType
+      'Viewer': viewerType
     });
 
 


### PR DESCRIPTION
This should do the trick. All you need to do is use `typeMapper` to associate the name and GraphQL type and it will correctly resolve it when using the `nodeInterface` and `nodeField` methods

Resolves https://github.com/mickhansen/graphql-sequelize/issues/30