### PR TITLE
Better support for enums with dashes

### DIFF
--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -58,8 +58,9 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
   if (sequelizeType instanceof ENUM) {
     return new GraphQLEnumType({
       values: sequelizeType.values.reduce((obj, value) => {
+        let sanitizedValue = value;
         if (specialChars.test(value)) {
-          value = value.split(specialChars).reduce((reduced, val, idx) => {
+          sanitizedValue = value.split(specialChars).reduce((reduced, val, idx) => {
             let newVal = val;
             if (idx > 0) {
               newVal = `${val[0].toUpperCase()}${val.slice(1)}`;
@@ -67,7 +68,7 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
             return `${reduced}${newVal}`;
           });
         }
-        obj[value] = {value};
+        obj[sanitizedValue] = {value};
         return obj;
       }, {})
     });

--- a/test/attributeFields.test.js
+++ b/test/attributeFields.test.js
@@ -39,7 +39,7 @@ describe('attributeFields', function () {
         type: Sequelize.ENUM('first', 'second')
       },
       enumTwo: {
-        type: Sequelize.ENUM('first', 'second')
+        type: Sequelize.ENUM('foo', 'foo-bar')
       },
       list: {
         type: Sequelize.ARRAY(Sequelize.STRING)
@@ -99,5 +99,13 @@ describe('attributeFields', function () {
 
     expect(fields.enum.type.name).to.equal(modelName + 'enum' + 'EnumType');
     expect(fields.enumTwo.type.name).to.equal(modelName + 'enumTwo' + 'EnumType');
+  });
+
+  it('should support enum values with characters not allowed by GraphQL', function () {
+    var fields = attributeFields(Model);
+
+    expect(fields.enumTwo.type.getValues()).to.not.be.undefined;
+    expect(fields.enumTwo.type.getValues()[1].name).to.equal('fooBar');
+    expect(fields.enumTwo.type.getValues()[1].value).to.equal('foo-bar');
   });
 });


### PR DESCRIPTION
Before, GraphQL would throw an error.
Now it works closer to what’s expected.
The value in GraphQL is still camelCased, but now it resolves properly.