### PR TITLE
Connections for no association.

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -100,7 +100,10 @@ module.exports = function (target, options) {
         });
       });
     }
-    return model[list ? 'findAll' : 'findOne'](findOptions).then(function (result) {
+    return model[list || isConnection(info.returnType) ? 'findAll' : 'findOne'](findOptions).then(function (result) {
+      if (options.handleConnection && isConnection(info.returnType)) {
+        result = handleConnection(result, args);
+      }
       return options.after(result, args, root, {
         ast: simpleAST,
         type: type,


### PR DESCRIPTION
Users connection is not associated with the viewer.
It can be used to query all users:
```
const {User} = sequelize.models;

const GraphQLUser = new GraphQLObjectType({
  name: 'User',
  fields: () => attributeFields(User, {globalId: true}),
  interfaces: () => [nodeInterface]
});

const GraphQLViewer = new GraphQLObjectType({
  name: 'Viewer',
  fields: () => {
    const usersConnection = sequelizeConnection({
      name: 'Users',
      nodeType: GraphQLUser,
      target: User // !!! no association
      /* orderBy, where, connectionFields, ... */
    })
    
    return {
      id: globalIdField('Viewer'),
      users: {
        type: usersConnection.connectionType,
        args: usersConnection.connectionArgs,
        resolve: usersConnection.resolve
      }
    }
  }
});
```