### PR TITLE
attributeFields - Map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,74 @@ userType = new GraphQLObjectType({
 });
 ```
 
+### Renaming generated fields
+
+attributeFields accepts a ```map``` option to customize the way the attribute fields are named. The ```map``` option accepts
+an object or a function that returns a string. 
+
+```js
+
+var Model = sequelize.define('User', {
+  email: {
+    type: Sequelize.STRING,
+    allowNull: false
+  },
+  firstName: {
+    type: Sequelize.STRING
+  },
+  lastName: {
+    type: Sequelize.STRING
+  }
+});
+
+attributeFields(Model, {
+    map:{
+        email:"Email",
+        firstName:"FirstName",
+        lastName:"LastName"
+    }
+});
+
+/*
+{
+  id: {
+    type: new GraphQLNonNull(GraphQLInt)
+  },
+  Email: {
+    type: new GraphQLNonNull(GraphQLString)
+  },
+  FirstName: {
+    type: GraphQLString
+  },
+  LastName: {
+    type: GraphQLString
+  }
+}
+*/
+
+attributeFields(Model, {
+    map:(k) => k.toLowerCase()
+});
+
+/*
+{
+  id: {
+    type: new GraphQLNonNull(GraphQLInt)
+  },
+  email: {
+    type: new GraphQLNonNull(GraphQLString)
+  },
+  firstname: {
+    type: GraphQLString
+  },
+  lastname: {
+    type: GraphQLString
+  }
+}
+*/
+
+```
+
 ### ENUM attributes with non-alphanumeric characters
 
 GraphQL enum types [only support ASCII alphanumeric characters and underscores](https://facebook.github.io/graphql/#Name).

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -12,26 +12,25 @@ module.exports = function (Model, options) {
     var attribute = Model.rawAttributes[key]
       , type = attribute.type;
 
-    // determine the key
-    var mappedKey = key;
+
     if (options.map) {
       if (typeof options.map === 'function') {
-        mappedKey = options.map(key);
+        key = options.map(key) || key;
       } else {
-        mappedKey = options.map[key] || key;
+        key = options.map[key] || key;
       }
     }
 
-    memo[mappedKey] = {
+    memo[key] = {
       type: typeMapper.toGraphQL(type, Model.sequelize.constructor)
     };
 
-    if (memo[mappedKey].type instanceof GraphQLEnumType ) {
-      memo[mappedKey].type.name = `${Model.name}${mappedKey}EnumType`;
+    if (memo[key].type instanceof GraphQLEnumType ) {
+      memo[key].type.name = `${Model.name}${key}EnumType`;
     }
 
     if (attribute.allowNull === false || attribute.primaryKey === true) {
-      memo[mappedKey].type = new GraphQLNonNull(memo[mappedKey].type);
+      memo[key].type = new GraphQLNonNull(memo[key].type);
     }
 
     return memo;

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -12,16 +12,26 @@ module.exports = function (Model, options) {
     var attribute = Model.rawAttributes[key]
       , type = attribute.type;
 
-    memo[key] = {
+    // determine the key
+    var mappedKey = key;
+    if (options.map) {
+      if (typeof options.map === 'function') {
+        mappedKey = options.map(key);
+      } else {
+        mappedKey = options.map[key] || key;
+      }
+    }
+
+    memo[mappedKey] = {
       type: typeMapper.toGraphQL(type, Model.sequelize.constructor)
     };
 
-    if (memo[key].type instanceof GraphQLEnumType ) {
-      memo[key].type.name = `${Model.name}${key}EnumType`;
+    if (memo[mappedKey].type instanceof GraphQLEnumType ) {
+      memo[mappedKey].type.name = `${Model.name}${mappedKey}EnumType`;
     }
 
     if (attribute.allowNull === false || attribute.primaryKey === true) {
-      memo[key].type = new GraphQLNonNull(memo[key].type);
+      memo[mappedKey].type = new GraphQLNonNull(memo[mappedKey].type);
     }
 
     return memo;

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -92,6 +92,17 @@ describe('attributeFields', function () {
     expect(fields.virtualBoolean.type).to.equal(GraphQLBoolean);
   });
 
+  it('should be possible to rename fields with a object map',function () {
+    var fields = attributeFields(Model,{map:{"id":"mappedId"}});
+    expect(Object.keys(fields)).to.deep.equal(['mappedId', 'email', 'firstName', 'lastName', 'float', 'decimal', 'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean']);
+  });
+  it('should be possible to rename fields with a function that maps keys',function () {
+    var fields = attributeFields(Model,{map:function(k){
+      return k+'s'
+    }});
+    expect(Object.keys(fields)).to.deep.equal(['ids', 'emails', 'firstNames', 'lastNames', 'floats', 'decimals', 'enums', 'enumTwos', 'lists', 'virtualIntegers', 'virtualBooleans']);
+  });
+
   it('should be possible to exclude fields', function () {
     var fields = attributeFields(Model, {
       exclude: ['id', 'email', 'float', 'decimal', 'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean']


### PR DESCRIPTION
This PR implements the map option for attributeFields with an object hash and function. Included are two unit tests that cover using a function or using an object hash