### PR TITLE
check for existance of PK before adding it as resolver attributes

### DIFF
--- a/src/defaultArgs.js
+++ b/src/defaultArgs.js
@@ -7,11 +7,13 @@ module.exports = function (Model) {
     , attribute = Model.rawAttributes[key]
     , type;
 
-  type = new GraphQLNonNull(typeMapper.toGraphQL(attribute.type, Model.sequelize.constructor));
+  if (key && attribute) {
+    type = new GraphQLNonNull(typeMapper.toGraphQL(attribute.type, Model.sequelize.constructor));
 
-  result[key] = {
-    type: type
-  };
+    result[key] = {
+      type: type
+    };
+  }
 
   return result;
 };

--- a/src/generateIncludes.js
+++ b/src/generateIncludes.js
@@ -81,7 +81,7 @@ export default function generateIncludes(simpleAST, type, root, options) {
 
       if (association.associationType === 'BelongsTo') {
         result.attributes.push(association.foreignKey);
-      } else {
+      } else if (association.source.primaryKeyAttribute) {
         result.attributes.push(association.source.primaryKeyAttribute);
       }
 
@@ -102,7 +102,9 @@ export default function generateIncludes(simpleAST, type, root, options) {
           delete includeOptions.order;
         }
 
-        includeOptions.attributes.push(association.target.primaryKeyAttribute);
+        if (association.target.primaryKeyAttribute) {
+          includeOptions.attributes.push(association.target.primaryKeyAttribute);
+        }
 
         if (association.associationType === 'HasMany') {
           includeOptions.attributes.push(association.foreignKey);

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -65,7 +65,9 @@ function resolverFactory(target, options) {
       findOptions.attributes = targetAttributes;
     }
 
-    findOptions.attributes.push(model.primaryKeyAttribute);
+    if (model.primaryKeyAttribute) {
+      findOptions.attributes.push(model.primaryKeyAttribute);
+    }
 
     includeResult = generateIncludes(
       simpleAST,


### PR DESCRIPTION
This PR handles the case where someone working with legacy tables doesn't have a PK and deletes the PK attribute from their model. 