### PR TITLE
added the ability to supply a custom mapType function to the typeMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,51 @@ userType = new GraphQLObjectType({
   })
 });
 ```
+### Providing custom types
+
+`attributeFields` uses the graphql-sequelize `typeMapper` to map Sequelize types to GraphQL types. You can supply your own
+mapping function to override this behavior using the `mapType` export.
+
+```js
+var Model = sequelize.define('User', {
+  email: {
+    type: Sequelize.STRING,
+    allowNull: false
+  },
+  isValid: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false
+  }
+});
+
+import {attributeFields,typeMapper} from 'graphql-sequelize';
+typeMapper.mapType((type) => {s
+   //map bools as strings
+   if (type instanceof Sequelize.BOOLEAN) {
+     return GraphQLString
+   }
+   //use default for everything else
+   return false
+});
+
+//map fields
+attributeFields(Model);
+
+/*
+{
+  id: {
+    type: new GraphQLNonNull(GraphQLInt)
+  },
+  email: {
+    type: new GraphQLNonNull(GraphQLString)
+  },
+  isValid: {
+      type: new GraphQLNonNull(GraphQLString)
+  },
+}
+*/
+
+```
 
 ### Renaming generated fields
 

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -1,11 +1,21 @@
 import {
-  GraphQLInt,
-  GraphQLString,
+   GraphQLInt,
+   GraphQLString,
    GraphQLBoolean,
    GraphQLFloat,
    GraphQLEnumType,
    GraphQLList
  } from 'graphql';
+
+let customTypeMapper;
+/**
+ * A function to set a custom mapping of types
+ * @param {Function} mapFunc
+ */
+export function mapType(mapFunc) {
+  customTypeMapper = mapFunc;
+}
+
 
 /**
  * Checks the type of the sequelize data type and
@@ -15,6 +25,14 @@ import {
  * @return {Function} GraphQL type declaration
  */
 export function toGraphQL(sequelizeType, sequelizeTypes) {
+
+  // did the user supply a mapping function?
+  // use their mapping, if it returns truthy
+  // else use our defaults
+  if (customTypeMapper) {
+    let result = customTypeMapper(sequelizeType);
+    if (result) return result;
+  }
 
   const {
     BOOLEAN,
@@ -34,6 +52,8 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
     ARRAY,
     VIRTUAL
   } = sequelizeTypes;
+
+
 
   // Regex for finding special characters
   const specialChars = /[^a-z\d_]/i;

--- a/test/unit/typeMapper.test.js
+++ b/test/unit/typeMapper.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { toGraphQL } from '../../src/typeMapper';
+import { mapType, toGraphQL } from '../../src/typeMapper';
 
 import Sequelize from 'sequelize';
 
@@ -18,7 +18,7 @@ const {
   DATEONLY,
   ARRAY,
   VIRTUAL
-} = Sequelize;
+  } = Sequelize;
 
 import {
   GraphQLString,
@@ -30,6 +30,34 @@ import {
 } from 'graphql';
 
 describe('typeMapper', () => {
+
+  describe('CUSTOM', function () {
+    before(function () {
+      //setup mapping
+      mapType((type)=> {
+        if (type instanceof BOOLEAN) {
+          return GraphQLString
+        }
+        if (type instanceof FLOAT) {
+          return false
+        }
+      });
+    });
+    it('should fallback to default types if it returns false', function () {
+      expect(toGraphQL(new FLOAT(), Sequelize)).to.equal(GraphQLFloat);
+    });
+    it('should allow the user to map types to anything', function () {
+      expect(toGraphQL(new BOOLEAN(), Sequelize)).to.equal(GraphQLString);
+    });
+
+    //reset mapType
+    after(function () {
+      mapType(null);
+    });
+
+  });
+
+
   describe('DOUBLE', function () {
     it('should map to GraphQLFloat', function () {
       expect(toGraphQL(new DOUBLE(), Sequelize)).to.equal(GraphQLFloat);


### PR DESCRIPTION
This resolves #126 and gives users the ability to override the mapping of types with a custom function. Added tests to typeMapper.test.js and updated readme.