### PR TITLE
initial where implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ fullName: {
 
 ### defaultArgs
 
-`defaultArgs(Model)` will return an object containing an arg with a key and type matching your models primary key.
+`defaultArgs(Model)` will return an object containing an arg with a key and type matching your models primary key and 
+the "where" argument for passing complex query operations described [here](http://docs.sequelizejs.com/en/latest/docs/querying/)
 
 ```js
 var Model = sequelize.define('User', {
@@ -364,7 +365,10 @@ defaultArgs(Model);
 /*
 {
   project_id: {
-    type: new GraphQLNonNull(GraphQLString)
+    type: GraphQLString
+  },
+   where: {
+      type JSONType
   }
 }
 */
@@ -381,12 +385,15 @@ defaultArgs(Model);
   },
   order: {
     type: GraphQLString
+  },
+  where: {
+    type JSONType 
   }
 }
 ```
 
 Which when added to args will let the resolver automatically support limit and ordering in args for graphql queries.
-Should be used with fields of type `GraphQLList`
+Should be used with fields of type `GraphQLList`.
 
 ```js
 import {defaultListArgs} from 'graphql-sequelize'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src",
     "build": "rm -rf lib/* && babel src --ignore test --optional runtime --out-dir lib",
     "test": "npm run test-unit && npm run test-docker",
+    "test-watch": "npm run test-unit -- --watch",
     "test-unit": "mocha $npm_package_options_mocha test/unit/*.test.js test/unit/**/*.test.js",
     "build-docker": "docker-compose build",
     "test-docker": "docker-compose run dev /bin/sh -c \"npm run test-integration\"",

--- a/src/argsToFindOptions.js
+++ b/src/argsToFindOptions.js
@@ -1,3 +1,5 @@
+import {replaceWhereOperators} from './replaceWhereOperators';
+
 export default function argsToFindOptions(args, target) {
   var result = {}
     , targetAttributes = Object.keys(target.rawAttributes);
@@ -24,6 +26,12 @@ export default function argsToFindOptions(args, target) {
           result.order = [[args[key], 'ASC']];
         }
       }
+
+      if (key === 'where' && args[key]) {
+        // setup where
+        result.where = replaceWhereOperators(args.where);
+      }
+
     });
   }
 

--- a/src/defaultArgs.js
+++ b/src/defaultArgs.js
@@ -1,5 +1,5 @@
 import * as typeMapper from './typeMapper';
-import { GraphQLNonNull } from 'graphql';
+import JSONType from './types/jsonType';
 
 module.exports = function (Model) {
   var result = {}
@@ -8,12 +8,17 @@ module.exports = function (Model) {
     , type;
 
   if (key && attribute) {
-    type = new GraphQLNonNull(typeMapper.toGraphQL(attribute.type, Model.sequelize.constructor));
-
+    type = typeMapper.toGraphQL(attribute.type, Model.sequelize.constructor);
     result[key] = {
       type: type
     };
   }
+
+  // add where
+  result.where = {
+    type: JSONType,
+    description: 'A JSON object conforming the the shape specified in http://docs.sequelizejs.com/en/latest/docs/querying/'
+  };
 
   return result;
 };

--- a/src/defaultListArgs.js
+++ b/src/defaultListArgs.js
@@ -1,4 +1,5 @@
 import { GraphQLInt, GraphQLString } from 'graphql';
+import JSONType from './types/jsonType';
 
 module.exports = function () {
   return {
@@ -7,6 +8,11 @@ module.exports = function () {
     },
     order: {
       type: GraphQLString
+    },
+    where: {
+      type: JSONType,
+      description: 'A JSON object conforming the the shape specified in http://docs.sequelizejs.com/en/latest/docs/querying/'
     }
   };
+
 };

--- a/src/replaceWhereOperators.js
+++ b/src/replaceWhereOperators.js
@@ -1,0 +1,61 @@
+/**
+ * Replace a key deeply in an object
+ * @param obj
+ * @param keyMap
+ * @returns {Object}
+ */
+function replaceKeyDeep(obj, keyMap) {
+  return Object.keys(obj).reduce((memo, key)=> {
+
+    // determine which key we are going to use
+    let targetKey = keyMap[key] ? keyMap[key] : key;
+
+    // assign the new value
+    memo[targetKey] = obj[key];
+
+    // recurse if an array
+    if (Array.isArray(memo[targetKey])) {
+      memo[targetKey].forEach((val, idx) => {
+        if (Object.prototype.toString.call(val) === '[object Object]') {
+          memo[targetKey][idx] = replaceKeyDeep(val, keyMap);
+        }
+      });
+    } else if (Object.prototype.toString.call(memo[targetKey]) === '[object Object]') {
+      // recurse if Object
+      memo[targetKey] = replaceKeyDeep(memo[targetKey], keyMap);
+    }
+
+    // return the modified object
+    return memo;
+  }, {});
+}
+
+/**
+ * Replace the where arguments object and return the sequelize compatible version.
+ * @param where arguments object in GraphQL Safe format meaning no leading "$" chars.
+ * @returns {Object}
+ */
+export function replaceWhereOperators(where) {
+  return replaceKeyDeep(where, {
+    and: '$and',
+    or: '$or',
+    gt: '$gt',
+    gte: '$gte',
+    lt: '$lt',
+    lte: '$lte',
+    ne: '$ne',
+    between: '$between',
+    notBetween: '$notBetween',
+    in: '$in',
+    notIn: '$notIn',
+    notLike: '$notLike',
+    iLike: '$iLike',
+    notILike: '$notILike',
+    like: '$like',
+    overlap: '$overlap',
+    contains: '$contains',
+    contained: '$contained',
+    any: '$any',
+    col: '$col'
+  });
+}

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -59,8 +59,8 @@ function resolverFactory(target, options) {
 
     if (options.filterAttributes) {
       findOptions.attributes = Object.keys(fields)
-                             .map(key => fields[key].key || key)
-                             .filter(inList.bind(null, targetAttributes));
+        .map(key => fields[key].key || key)
+        .filter(inList.bind(null, targetAttributes));
     } else {
       findOptions.attributes = targetAttributes;
     }
@@ -95,6 +95,7 @@ function resolverFactory(target, options) {
       findOptions.order = [model.primaryKeyAttribute, 'ASC'];
     }
 
+
     if (association) {
       return source[association.accessors.get](findOptions).then(function (result) {
         if (options.handleConnection && isConnection(info.returnType)) {
@@ -107,6 +108,7 @@ function resolverFactory(target, options) {
         });
       });
     }
+
     return model[list ? 'findAll' : 'findOne'](findOptions).then(function (result) {
       return options.after(result, args, root, {
         ast: simpleAST,

--- a/src/types/jsonType.js
+++ b/src/types/jsonType.js
@@ -1,0 +1,55 @@
+import {
+  GraphQLScalarType,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLBoolean,
+  GraphQLString
+} from 'graphql';
+
+import { Kind } from 'graphql/language';
+
+
+const astToJson = {
+  [Kind.INT](ast) {
+    return GraphQLInt.parseLiteral(ast);
+  },
+  [Kind.FLOAT](ast) {
+    return GraphQLFloat.parseLiteral(ast);
+  },
+  [Kind.BOOLEAN](ast) {
+    return GraphQLBoolean.parseLiteral(ast);
+  },
+  [Kind.STRING](ast) {
+    return GraphQLString.parseLiteral(ast);
+  },
+  [Kind.ENUM](ast) {
+    return String(ast.value);
+  },
+  [Kind.LIST](ast) {
+    return ast.values.map(astItem => {
+      return JSONType.parseLiteral(astItem);
+    });
+  },
+  [Kind.OBJECT](ast) {
+    let obj = {};
+    ast.fields.forEach(field => {
+      obj[field.name.value] = JSONType.parseLiteral(field.value);
+    });
+    return obj;
+  }
+};
+
+
+const JSONType = new GraphQLScalarType({
+  name: 'JSON',
+  description: 'The `JSON` scalar type represents raw JSON as values.',
+  serialize: value => value,
+  parseValue: value => value,
+  parseLiteral: ast => {
+    const parser = astToJson[ast.kind];
+    return parser ? parser.call(this, ast) : null;
+  }
+});
+
+
+export default JSONType;

--- a/test/unit/defaultArgs.test.js
+++ b/test/unit/defaultArgs.test.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , helper = require('./helper')
-  , sequelize = helper.sequelize
-  , Sequelize = require('sequelize')
-  , defaultArgs = require('../../src/defaultArgs');
+
+import chai, {expect} from "chai";
+import helper,{sequelize} from "./helper";
+import Sequelize from "sequelize";
+import JSONType from "../../src/types/jsonType";
+import defaultArgs from "../../src/defaultArgs";
 
 import {
   GraphQLString,
   GraphQLInt,
-  GraphQLNonNull
+  GraphQLNonNull,
+  GraphQLScalarType
 } from 'graphql';
 
 describe('defaultArgs', function () {
@@ -18,20 +19,19 @@ describe('defaultArgs', function () {
     var Model
       , args;
 
-    Model = sequelize.define(Math.random().toString(), {});
+    Model = sequelize.define('DefaultArgModel', {});
 
     args = defaultArgs(Model);
 
     expect(args).to.have.ownProperty('id');
-    expect(args.id.type).to.be.an.instanceOf(GraphQLNonNull);
-    expect(args.id.type.ofType).to.equal(GraphQLInt);
+    expect(args.id.type).to.equal(GraphQLInt);
   });
 
   it('should return a key for a string primary key', function () {
     var Model
       , args;
 
-    Model = sequelize.define(Math.random().toString(), {
+    Model = sequelize.define('DefaultArgModel', {
       modelId: {
         type: Sequelize.STRING,
         primaryKey: true
@@ -40,15 +40,14 @@ describe('defaultArgs', function () {
 
     args = defaultArgs(Model);
 
-    expect(args.modelId.type).to.be.an.instanceOf(GraphQLNonNull);
-    expect(args.modelId.type.ofType).to.equal(GraphQLString);
+    expect(args.modelId.type).to.equal(GraphQLString);
   });
 
   it('should return a key for a string primary key', function () {
     var Model
       , args;
 
-    Model = sequelize.define(Math.random().toString(), {
+    Model = sequelize.define('DefaultArgModel', {
       uuid: {
         type: Sequelize.UUID,
         primaryKey: true
@@ -57,7 +56,29 @@ describe('defaultArgs', function () {
 
     args = defaultArgs(Model);
 
-    expect(args.uuid.type).to.be.an.instanceOf(GraphQLNonNull);
-    expect(args.uuid.type.ofType).to.equal(GraphQLString);
+    expect(args.uuid.type).to.equal(GraphQLString);
   });
+
+  describe('will have an "where" argument', function () {
+
+    it('that is an GraphQLScalarType', function () {
+      var Model
+        , args;
+
+      Model = sequelize.define('DefaultArgModel', {
+        modelId: {
+          type: Sequelize.STRING,
+          primaryKey: true
+        }
+      });
+
+      args = defaultArgs(Model);
+
+      expect(args).to.have.ownProperty('where');
+      expect(args.where.type).to.be.an.instanceOf(GraphQLScalarType);
+    });
+
+  });
+
+
 });

--- a/test/unit/defaultListArgs.test.js
+++ b/test/unit/defaultListArgs.test.js
@@ -1,13 +1,18 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , defaultListArgs = require('../../src/defaultListArgs');
+import chai, {expect} from "chai";
+import helper,{sequelize} from "./helper";
+import Sequelize from "sequelize";
+import defaultListArgs from "../../src/defaultListArgs";
+
 
 import {
   GraphQLString,
-  GraphQLInt
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLScalarType
 } from 'graphql';
+
 
 describe('defaultListArgs', function () {
   it('should return a limit key', function () {
@@ -23,4 +28,26 @@ describe('defaultListArgs', function () {
     expect(args).to.have.ownProperty('order');
     expect(args.order.type).to.equal(GraphQLString);
   });
+
+  describe('will have an "where" argument', function () {
+
+    it('that is an GraphQLScalarType', function () {
+      var Model
+        , args;
+
+      Model = sequelize.define('DefaultArgModel', {
+        modelId: {
+          type: Sequelize.STRING,
+          primaryKey: true
+        }
+      });
+
+      args = defaultListArgs(Model);
+
+      expect(args).to.have.ownProperty('where');
+      expect(args.where.type).to.be.an.instanceOf(GraphQLScalarType);
+    });
+
+  });
+
 });

--- a/test/unit/replaceWhereOperators.test.js
+++ b/test/unit/replaceWhereOperators.test.js
@@ -1,0 +1,61 @@
+import chai, {expect} from "chai";
+import {replaceWhereOperators} from "../../src/replaceWhereOperators";
+
+describe("replaceWhereOperators", ()=> {
+  it("should take an Object of grapqhl-friendly keys and replace with the correct sequelize operators", ()=> {
+    let before = {
+      and: 1,
+      or: "1",
+      gt: [{and: "1", or: "1"}, {between: "1", overlap: "1"}],
+      gte: 1,
+      lt: {
+        and: {
+          "test": [{or: "1"}]
+        }
+      },
+      lte: 1,
+      ne: 1,
+      between: 1,
+      notBetween: 1,
+      in: 1,
+      notIn: 1,
+      notLike: 1,
+      iLike: 1,
+      notILike: 1,
+      like: 1,
+      overlap: 1,
+      contains: 1,
+      contained: 1,
+      any: 1,
+      col: 1
+    };
+    let after = {
+      $and: 1,
+      $or: "1",
+      $gt: [{$and: "1", $or: "1"}, {$between: "1", $overlap: "1"}],
+      $gte: 1,
+      $lt: {
+        $and: {
+          "test": [{$or: "1"}]
+        }
+      },
+      $lte: 1,
+      $ne: 1,
+      $between: 1,
+      $notBetween: 1,
+      $in: 1,
+      $notIn: 1,
+      $notLike: 1,
+      $iLike: 1,
+      $notILike: 1,
+      $like: 1,
+      $overlap: 1,
+      $contains: 1,
+      $contained: 1,
+      $any: 1,
+      $col: 1
+    };
+
+    expect(replaceWhereOperators(before)).to.deep.equal(after);
+  })
+});


### PR DESCRIPTION
This PR implements a "where" arg on the defaultArgs and defaultListArgs. This implementation is slightly naive but does a few things -

* Implements a custom Scalar type called "JSONType", inspired by - https://github.com/graphql/graphql-js/pull/242

* Maps the operators defined [here](http://docs.sequelizejs.com/en/latest/docs/querying/) to add back the "$" since that isn't an allowed character in GraphQL InputTypes

* Makes the primary_key arg on defaultArgs nullable, since you don't need it if you are providing a "where" query.

I say that it is naive because it would be nice to map the where operators for each model to concrete types, but I struggled with this because of the possibility of nested "$and" and "$or" values in the "where" queries defined by sequelize. I was close to getting this implemented, but I think this is a wholly acceptable solution for the time being. 

This PR resolves issue #145 