### PR TITLE
ability to bypass NonNull

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ attributeFields(Model, {
   exclude: [], // array of model attributes to ignore - default: []
   only: [], // only generate definitions for these model attributes - default: null
   globalId: true, // return an relay global id field - default: false
-  map: {} // rename fields - default: {}
+  map: {}, // rename fields - default: {}
+  allowNull: false, // disable wrapping mandatory fields in `GraphQLNonNull` - default: false
 });
 
 /*

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -2,9 +2,7 @@ import * as typeMapper from './typeMapper';
 import { GraphQLNonNull, GraphQLEnumType } from 'graphql';
 import { globalIdField } from 'graphql-relay';
 
-module.exports = function (Model, options) {
-  options = options || {};
-
+module.exports = function (Model, options = {}) {
   var result = Object.keys(Model.rawAttributes).reduce(function (memo, key) {
     if (options.exclude && ~options.exclude.indexOf(key)) return memo;
     if (options.only && !~options.only.indexOf(key)) return memo;
@@ -29,8 +27,10 @@ module.exports = function (Model, options) {
       memo[key].type.name = `${Model.name}${key}EnumType`;
     }
 
-    if (attribute.allowNull === false || attribute.primaryKey === true) {
-      memo[key].type = new GraphQLNonNull(memo[key].type);
+    if (!options.allowNull) {
+      if (attribute.allowNull === false || attribute.primaryKey === true) {
+        memo[key].type = new GraphQLNonNull(memo[key].type);
+      }
     }
 
     return memo;

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -239,5 +239,14 @@ describe('attributeFields', function () {
         email: 'idris@example.com'
       })).to.equal(toGlobalId(ModelWithoutId.name, 'idris@example.com'));
     });
+
+    it('should be possible to bypass NonNull', function () {
+      var fields = attributeFields(Model, {
+        allowNull: true,
+      });
+
+      expect(fields.email.type).to.not.be.an.instanceOf(GraphQLNonNull);
+      expect(fields.email.type).to.equal(GraphQLString);
+    });
   });
 });


### PR DESCRIPTION
Useful when using `attributeFields()` in update mutations where some of the fields might be optional.