### PR TITLE
Don't deepMerge strings. It causes an infinite loop

### DIFF
--- a/src/simplifyAST.js
+++ b/src/simplifyAST.js
@@ -2,7 +2,7 @@ function deepMerge(a, b) {
   Object.keys(b).forEach(function (key) {
     if (['fields', 'args'].indexOf(key) !== -1) return;
 
-    if (a[key] && b[key]) {
+    if (a[key] && b[key] && typeof a[key] === 'object' && typeof b[key] === 'object') {
       a[key] = deepMerge(a[key], b[key]);
     } else {
       a[key] = b[key];


### PR DESCRIPTION
Version 0.21.0 introduced an infinite loop for my app.  In deepMerge, it hits a string and then keeps recursing onto the first character of the string.  This bug was introduced in 77e1edd56cfc205ed24a3ff23916498e78c047b9 when `_.merge` was replaced.

This pull request makes deepMerge only recurse on objects.

I tried to write a test case, but couldn't get it to fail.  This code fixes my app though.  If it's useful, here's the GraphQL in my app that causes the loop:
```
query ViewerQueries {
  viewer {
    _subscriptions2JZtYG: subscriptions(first: 100) {
      edges {
        node {
          _monitors4cE1PA: monitors(first: 1) {
            edges {
              node {
                id
              }
            }
          }
          ...F7
        }
      }
    }
  }
}

fragment F7 on Subscription {
  _monitors4cE1PA: monitors(first: 1) {
    edges {
      node {
        id
      }
    }
  }
}
```

What causes the issue is that I have monitors in a fragment and outside of a fragment.  This is the narrowest case I can make it fail for.  If I remove the fragment F7, it works.

The string that it tries to recurse on is "monitors".