### PR TITLE
[RFC] Support defaultAttributes in sequalizeConnection

### DIFF
--- a/test/integration/relay.test.js
+++ b/test/integration/relay.test.js
@@ -1,15 +1,12 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , resolver = require('../../src/resolver')
-  , helper = require('./helper')
-  , sequelize = helper.sequelize
-  , Sequelize = require('sequelize')
-  , Promise = helper.Promise
-  , sinon = require('sinon')
-  , attributeFields = require('../../src/attributeFields')
-  , _ = require('lodash');
+import { expect } from 'chai';
+import resolver from '../../src/resolver';
+import { sequelize, Promise } from './helper';
+import Sequelize from 'sequelize';
+import sinon from 'sinon';
+import attributeFields from '../../src/attributeFields';
+import _ from 'lodash';
 
 import {
   GraphQLString,

--- a/test/integration/relay.test.js
+++ b/test/integration/relay.test.js
@@ -282,7 +282,7 @@ describe('relay', function () {
     return this.project.setUsers([this.userA.id, this.userB.id]);
   });
 
-  it('should support unassociated GraphQL types', function() {
+  it('should support unassociated GraphQL types', function () {
     var globalId = toGlobalId('Viewer');
     return graphql(schema, `
       {
@@ -296,7 +296,7 @@ describe('relay', function () {
 
   });
 
-  it('should return userA when running a node query', function() {
+  it('should return userA when running a node query', function () {
     var user = this.userA
       , globalId = toGlobalId('User', user.id);
 
@@ -315,8 +315,8 @@ describe('relay', function () {
     });
   });
 
-  describe('node queries', function() {
-    it('should allow returning a custom entity', function() {
+  describe('node queries', function () {
+    it('should allow returning a custom entity', function () {
       generateCustom(1).then(custom => {
         const globalId = toGlobalId('Custom', custom.id);
 
@@ -337,7 +337,7 @@ describe('relay', function () {
     });
   });
 
-  it('should support first queries on connections', function() {
+  it('should support first queries on connections', function () {
     var user = this.userB;
 
     return graphql(schema, `
@@ -373,7 +373,7 @@ describe('relay', function () {
     });
   });
 
-  it('should support last queries on connections', function() {
+  it('should support last queries on connections', function () {
     var user = this.userB;
 
     return graphql(schema, `
@@ -410,7 +410,7 @@ describe('relay', function () {
   });
 
   // these two tests are not determenistic on postgres currently
-  it.skip('should support after queries on connections', function() {
+  it.skip('should support after queries on connections', function () {
     var user = this.userA;
 
     return graphql(schema, `

--- a/test/integration/relay.test.js
+++ b/test/integration/relay.test.js
@@ -270,11 +270,11 @@ describe('relay', function () {
           include: [User.Tasks]
         })
       ).bind(this).spread(function (project, userA, userB) {
-          this.project = project;
-          this.userA = userA;
-          this.userB = userB;
-          this.users = [userA, userB];
-        });
+        this.project = project;
+        this.userA = userA;
+        this.userB = userB;
+        this.users = [userA, userB];
+      });
     });
   });
 

--- a/test/integration/relay.test.js
+++ b/test/integration/relay.test.js
@@ -32,7 +32,7 @@ function generateTask(id) {
   return {
     id: id,
     name: Math.random().toString()
-  }
+  };
 }
 
 const generateCustom = Promise.method(id => {
@@ -445,7 +445,7 @@ describe('relay', function () {
             }
           }
         }
-      `)
+      `);
     })
     .then(function (result) {
       expect(result.data.user.tasks.edges[0].node.name).to.equal(user.taskItems[1].name);

--- a/test/integration/relay.test.js
+++ b/test/integration/relay.test.js
@@ -5,16 +5,11 @@ import resolver from '../../src/resolver';
 import { sequelize, Promise } from './helper';
 import Sequelize from 'sequelize';
 import sinon from 'sinon';
-import attributeFields from '../../src/attributeFields';
-import _ from 'lodash';
 
 import {
   GraphQLString,
   GraphQLInt,
-  GraphQLFloat,
   GraphQLNonNull,
-  GraphQLBoolean,
-  GraphQLEnumType,
   GraphQLList,
   GraphQLObjectType,
   GraphQLSchema,
@@ -31,7 +26,6 @@ import {
   fromGlobalId,
   connectionDefinitions,
   connectionArgs,
-  connectionFromArray
 } from 'graphql-relay';
 
 function generateTask(id) {
@@ -53,12 +47,10 @@ describe('relay', function () {
     , Task
     , userType
     , taskType
-    , taskConnection
     , nodeInterface
     , Project
     , projectType
     , viewerType
-    , userConnection
     , nodeField
     , schema;
 
@@ -529,8 +521,7 @@ describe('relay', function () {
   });
 
   it('should resolve nested connections', function () {
-    var project = this.project
-      , sqlSpy = sinon.spy();
+    var sqlSpy = sinon.spy();
 
     return graphql(schema, `
       {
@@ -574,8 +565,7 @@ describe('relay', function () {
   });
 
   it('should resolve nested connections with a include: false top level node', function () {
-    var project = this.project
-      , sqlSpy = sinon.spy();
+    var sqlSpy = sinon.spy();
 
     return graphql(schema, `
       {


### PR DESCRIPTION
Closes #241

Can't seem to get this working yet. So far I've added a failing test, but my implementation doesn't seem to be working. I thought it could just just collect the option in `sequalizeConnection` and pass it down to the resolver as an extra option, but it seems to be bailing early on `after` before it has time to change the `findOptions`. Any help pointing me to the right place would be super awesome.

I've also done some lite linting on the test file.
