### PR TITLE
simplifyAST: resolve array args

### DIFF
--- a/src/simplifyAST.js
+++ b/src/simplifyAST.js
@@ -64,7 +64,11 @@ module.exports = function simplifyAST(ast, info, parent) {
     }
 
     simpleAST.fields[key].args = selection.arguments.reduce(function (args, arg) {
-      args[arg.name.value] = arg.value.value;
+      if (arg.value.values) {
+        args[arg.name.value] = arg.value.values.map(value => value.value);
+      } else {
+        args[arg.name.value] = arg.value.value;
+      }
       return args;
     }, {});
 

--- a/test/integration/resolver.test.js
+++ b/test/integration/resolver.test.js
@@ -174,6 +174,21 @@ describe('resolver', function () {
               return options;
             }
           })
+        },
+        tasksByIds: {
+          type: new GraphQLList(taskType),
+          args: {
+            ids: {
+              type: new GraphQLList(GraphQLInt)
+            }
+          },
+          resolve: resolver(User.Tasks, {
+            before: (options, args) => {
+              options.where = options.where || {};
+              options.where.id = { $in: args.ids };
+              return options;
+            }
+          })
         }
       }
     });
@@ -1088,6 +1103,24 @@ describe('resolver', function () {
       result.data.users.forEach(function (user) {
         expect(user.name).to.equal('Delayed!');
       });
+    });
+  });
+
+  it('should resolve args from array to before', function () {
+    var user = this.userB;
+
+    return graphql(schema, `
+      {
+        user(id: ${user.get('id')}) {
+          tasksByIds(ids: [${user.tasks[0].get('id')}]) {
+            id
+          }
+        }
+      }
+    `).then(function (result) {
+      if (result.errors) throw new Error(result.errors[0].stack);
+
+      expect(result.data.user.tasksByIds.length).to.equal(1);
     });
   });
 

--- a/test/unit/simplifyAST.test.js
+++ b/test/unit/simplifyAST.test.js
@@ -72,6 +72,32 @@ describe('simplifyAST', function () {
     });
   });
 
+  it('should simplify a basic structure with array args', function () {
+    expect(simplifyAST(parse(`
+      {
+        luke: human(id: ["1000", "1003"]) {
+          name
+        }
+      }
+    `))).to.deep.equal({
+      args: {},
+      fields: {
+        luke: {
+          key: "human",
+          args: {
+            id: ["1000", "1003"]
+          },
+          fields: {
+            name: {
+              args: {},
+              fields: {}
+            }
+          }
+        }
+      }
+    })
+  });
+
   it('should simplify a basic structure with an inline fragment', function () {
     expect(simplifyAST(parse(`
       {


### PR DESCRIPTION
In case of an argument is an `GraphQLList`, simplifyAST resolves `undefined` as value. This PR fix it by mapping `arg.values[].value`.
