### PR TITLE
simplifyValue

### DIFF
--- a/test/unit/simplifyAST.test.js
+++ b/test/unit/simplifyAST.test.js
@@ -73,6 +73,32 @@ describe('simplifyAST', function () {
   it('should simplify a basic structure with array args', function () {
     expect(simplifyAST(parse(`
       {
+        luke: human(id: ["1000", "1003"]) {
+          name
+        }
+      }
+    `))).to.deep.equal({
+      args: {},
+      fields: {
+        luke: {
+          key: "human",
+          args: {
+            id: ["1000", "1003"]
+          },
+          fields: {
+            name: {
+              args: {},
+              fields: {}
+            }
+          }
+        }
+      }
+    })
+  });
+
+  it('should simplify a basic structure with nested array args', function () {
+    expect(simplifyAST(parse(`
+      {
         user(units: ["1", "2", ["3", ["4"], [["5"], "6"], "7"]]) {
           name
         }

--- a/test/unit/simplifyAST.test.js
+++ b/test/unit/simplifyAST.test.js
@@ -73,17 +73,45 @@ describe('simplifyAST', function () {
   it('should simplify a basic structure with array args', function () {
     expect(simplifyAST(parse(`
       {
-        luke: human(id: ["1000", "1003"]) {
+        user(units: ["1", "2", ["3", ["4"], [["5"], "6"], "7"]]) {
           name
         }
       }
     `))).to.deep.equal({
       args: {},
       fields: {
-        luke: {
-          key: "human",
+        user: {
           args: {
-            id: ["1000", "1003"]
+            units: ["1", "2", ["3", ["4"], [["5"], "6"], "7"]]
+          },
+          fields: {
+            name: {
+              args: {},
+              fields: {}
+            }
+          }
+        }
+      }
+    })
+  });
+
+  it('should simplify a basic structure with variable args', function () {
+    expect(simplifyAST(parse(`
+      {
+        user(id: $id) {
+          name
+        }
+      }
+    `), {
+      variableValues: {
+        id: "1"
+      }
+    })).to.deep.equal({
+      args: {},
+      fields: {
+        user: {
+          args: {
+            id: "1"
           },
           fields: {
             name: {


### PR DESCRIPTION
I use` GraphQLInputObjectType`s as custom args in Relay connection.
My args in the debugger [this line](https://github.com/mickhansen/graphql-sequelize/blob/master/src/simplifyAST.js#L76):
![debug1](https://cloud.githubusercontent.com/assets/8298965/16096469/7652fa32-3349-11e6-950d-b519f330403d.png)
![debug2](https://cloud.githubusercontent.com/assets/8298965/16096473/7bc04cea-3349-11e6-80ec-d4659d125fca.png)

`simplifyValue` fix this bug.
