### PR TITLE
Fixes #223. Add cache argument to attributeFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ var Model = sequelize.define('User', {
 
 import {attributeFields} from 'graphql-sequelize';
 
+var cache = {}; // Reusable cache of enum types
 attributeFields(Model, {
   // ... options
   exclude: [], // array of model attributes to ignore - default: []
@@ -164,6 +165,7 @@ attributeFields(Model, {
   globalId: true, // return an relay global id field - default: false
   map: {}, // rename fields - default: {}
   allowNull: false, // disable wrapping mandatory fields in `GraphQLNonNull` - default: false
+  cache: cache, // Cache enum types to prevent duplicate type name error - default: {}
 });
 
 /*

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ attributeFields(Model, {
   globalId: true, // return an relay global id field - default: false
   map: {}, // rename fields - default: {}
   allowNull: false, // disable wrapping mandatory fields in `GraphQLNonNull` - default: false
+  commentToDescription: false, // convert model comment to GraphQL description - default: false
   cache: cache, // Cache enum types to prevent duplicate type name error - default: {}
 });
 

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -26,13 +26,13 @@ module.exports = function (Model, options = {}) {
 
     if (memo[key].type instanceof GraphQLEnumType ) {
       var typeName = `${Model.name}${key}EnumType`;
-      // Check cache for existing type
+      /*
+      Cache enum types to prevent duplicate type name error
+      when calling attributeFields multiple times on the same model
+      */
       if (cache[typeName]) {
-        // Use cached type
-        // Prevent GraphQL error message
         memo[key].type = cache[typeName];
       } else {
-        // Not found in cache
         memo[key].type.name = typeName;
         cache[typeName] = memo[key].type;
       }

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -3,6 +3,7 @@ import { GraphQLNonNull, GraphQLEnumType } from 'graphql';
 import { globalIdField } from 'graphql-relay';
 
 module.exports = function (Model, options = {}) {
+  var cache = options.cache || {};
   var result = Object.keys(Model.rawAttributes).reduce(function (memo, key) {
     if (options.exclude && ~options.exclude.indexOf(key)) return memo;
     if (options.only && !~options.only.indexOf(key)) return memo;
@@ -24,7 +25,18 @@ module.exports = function (Model, options = {}) {
     };
 
     if (memo[key].type instanceof GraphQLEnumType ) {
-      memo[key].type.name = `${Model.name}${key}EnumType`;
+      var typeName = `${Model.name}${key}EnumType`;
+      // Check cache for existing type
+      if (cache[typeName]) {
+        // Use cached type
+        // Prevent GraphQL error message
+        memo[key].type = cache[typeName];
+      } else {
+        // Not found in cache
+        memo[key].type.name = typeName;
+        cache[typeName] = memo[key].type;
+      }
+
     }
 
     if (!options.allowNull) {

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -199,41 +199,53 @@ describe('attributeFields', function () {
     expect(fields.enumTwo.type.getValues()[0].value).to.equal('foo_bar');
   });
 
-  it('should not create multiple enum types with same name', function () {
+  it('should not create multiple enum types with same name when using cache', function () {
 
-    var fields1 = attributeFields(Model);
-    var fields2 = attributeFields(Model);
-
-    var object1 = new GraphQLObjectType({
-      name: 'Object1',
-      fields: fields1
-    });
-    var object2 = new GraphQLObjectType({
-      name: 'Object2',
-      fields: fields2
-    });
-
-    var schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'RootQueryType',
-        fields: {
-          object1: {
-            type: object1,
-            resolve: function () {
-              return {};
+    // Create Schema
+    var schemaFn = function (fields1, fields2) {
+      return function () {
+        var object1 = new GraphQLObjectType({
+          name: 'Object1',
+          fields: fields1
+        });
+        var object2 = new GraphQLObjectType({
+          name: 'Object2',
+          fields: fields2
+        });
+        return new GraphQLSchema({
+          query: new GraphQLObjectType({
+            name: 'RootQueryType',
+            fields: {
+              object1: {
+                type: object1,
+                resolve: function () {
+                  return {};
+                }
+              },
+              object2: {
+                type: object2,
+                resolve: function () {
+                  return {};
+                }
+              }
             }
-          },
-          object2: {
-            type: object2,
-            resolve: function () {
-              return {};
-            }
-          }
-        }
-      })
-    });
+          })
+        });
+      }
+    };
 
-    expect(schema).to.not.be.undefined;
+    // Bad: Will create multiple/duplicate types with same name
+    var fields1a = attributeFields(Model);
+    var fields2a = attributeFields(Model);
+
+    expect(schemaFn(fields1a, fields2a)).to.throw(Error);
+
+    // Good: Will use cache and not create mutliple/duplicate types with same name
+    var cache = {};
+    var fields1b = attributeFields(Model, {cache: cache});
+    var fields2b = attributeFields(Model, {cache: cache});
+
+    expect(schemaFn(fields1b, fields2b)).to.not.throw(Error);
 
   });
 

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -14,7 +14,9 @@ import {
   GraphQLNonNull,
   GraphQLBoolean,
   GraphQLEnumType,
-  GraphQLList
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLSchema
 } from 'graphql';
 
 import {
@@ -195,6 +197,44 @@ describe('attributeFields', function () {
     expect(fields.enumTwo.type.getValues()).to.not.be.undefined;
     expect(fields.enumTwo.type.getValues()[0].name).to.equal('foo_bar');
     expect(fields.enumTwo.type.getValues()[0].value).to.equal('foo_bar');
+  });
+
+  it('should not create multiple enum types with same name', function () {
+
+    var fields1 = attributeFields(Model);
+    var fields2 = attributeFields(Model);
+
+    var object1 = new GraphQLObjectType({
+      name: 'Object1',
+      fields: fields1
+    });
+    var object2 = new GraphQLObjectType({
+      name: 'Object2',
+      fields: fields2
+    });
+
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'RootQueryType',
+        fields: {
+          object1: {
+            type: object1,
+            resolve: function () {
+              return {};
+            }
+          },
+          object2: {
+            type: object2,
+            resolve: function () {
+              return {};
+            }
+          }
+        }
+      })
+    });
+
+    expect(schema).to.not.be.undefined;
+
   });
 
   describe('with non-default primary key', function () {


### PR DESCRIPTION
Issue #223.

### Usage
#### Before

```javascript
    // Bad: Will create multiple/duplicate types with same name
    var fields1a = attributeFields(Model);
    var fields2a = attributeFields(Model);
```

#### After

```javascript
    // Good: Will use cache and not create mutliple/duplicate types with same name
    var cache = {};
    var fields1b = attributeFields(Model, {cache: cache});
    var fields2b = attributeFields(Model, {cache: cache});
```