### PR TITLE
Fix issue with generateIncludes and __typename

### DIFF
--- a/src/generateIncludes.js
+++ b/src/generateIncludes.js
@@ -2,6 +2,10 @@ import argsToFindOptions from './argsToFindOptions';
 import {isConnection, nodeAST, nodeType} from './relay';
 import _ from 'lodash';
 
+const GRAPHQL_NATIVE_KEYS = [
+  '__typename',
+];
+
 function inList(list, attribute) {
   return ~list.indexOf(attribute);
 }
@@ -13,6 +17,11 @@ export default function generateIncludes(simpleAST, type, context, options) {
   options = options || {};
 
   return Promise.all(Object.keys(simpleAST.fields).map(function (key) {
+    if (inList(GRAPHQL_NATIVE_KEYS, key)) {
+      // Skip native grahphql keys
+      return;
+    }
+
     var association
       , fieldAST = simpleAST.fields[key]
       , name = fieldAST.key || key

--- a/test/integration/resolver.test.js
+++ b/test/integration/resolver.test.js
@@ -419,6 +419,27 @@ describe('resolver', function () {
     });
   });
 
+  it('should resolve a array result with a model and aliased includes and __typename', function () {
+    return graphql(schema, `
+      {
+        users {
+          name
+
+          first: tasks(limit: 1) {
+            title
+            __typename
+          }
+        }
+      }
+    `).then(function (result) {
+      if (result.errors) throw new Error(result.errors[0].stack);
+
+      result.data.users.forEach(function (user) {
+        expect(user.first[0].__typename).to.equal('Task');
+      });
+    });
+  });
+
   it('should resolve an array result with a single model', function () {
     var users = this.users;
 


### PR DESCRIPTION
When generateIncludes statements, if there was a `__typename` field present
grahphql-sequelize would try and treat it as a field on the Model and blow up
retrieving its `resolve` function.

This patch instead skips when it encounters a native GraphQL key. We may want
to add more of these later.

This was the error I was getting before:
```
TypeError: Cannot read property 'resolve' of undefined
    at node_modules/graphql-sequelize/lib/generateIncludes.js:37:45
    at Array.map (native)
    at generateIncludes (node_modules/graphql-sequelize/lib/generateIncludes.js:30:52)
    at resolver (node_modules/graphql-sequelize/lib/resolver.js:103:43)
    at resolver node_modules/graphql-sequelize/lib/relay.js:344:14)
```