### PR TITLE
Fix: Protect against missing type fields

### DIFF
--- a/src/generateIncludes.js
+++ b/src/generateIncludes.js
@@ -28,7 +28,7 @@ export default function generateIncludes(simpleAST, type, context, options) {
       , fieldType = type._fields[name] && type._fields[name].type
       , includeOptions
       , args = fieldAST.args
-      , includeResolver = type._fields[name].resolve
+      , includeResolver = type._fields[name] && type._fields[name].resolve
       , allowedAttributes
       , include;
 


### PR DESCRIPTION
So I know I'm missing a test for this fix, but I had a pretty hard time coming up with the exact integration test and didn't want to hold up the patch.

Where this came up was I have an InterfaceType, `Commentable`, that some of my Objects use. But in some of my queries I am asking for properties from the concrete Object that aren't fields on the interface. When that happens the `simpleAST.fields` includes the fields from the concrete Object, but `type` in the interface. This makes `type._fields[name]` undefined. This PR "fixes" the issue by skipping those fields that aren't in the interface. 

I think a more complete solution would be to fetch the concrete Object instead for the request, but I don't know enough about the inner working of this library or `graphql-js` yet to submit that at this time.

Let me know what you want to do moving forward. 