### PR TITLE
Allow functions for exclude and only options

### DIFF
--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -5,8 +5,14 @@ import { globalIdField } from 'graphql-relay';
 module.exports = function (Model, options = {}) {
   var cache = options.cache || {};
   var result = Object.keys(Model.rawAttributes).reduce(function (memo, key) {
-    if (options.exclude && ~options.exclude.indexOf(key)) return memo;
-    if (options.only && !~options.only.indexOf(key)) return memo;
+    if (options.exclude) {
+      if (typeof options.exclude === 'function' && options.exclude(key)) return memo;
+      if (Array.isArray(options.exclude) && ~options.exclude.indexOf(key)) return memo;
+    }
+    if (options.only) {
+      if (typeof options.only === 'function' && !options.only(key)) return memo;
+      if (Array.isArray(options.only) && !~options.only.indexOf(key)) return memo;
+    }
 
     var attribute = Model.rawAttributes[key]
       , type = attribute.type;

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -153,9 +153,29 @@ describe('attributeFields', function () {
     expect(Object.keys(fields)).to.deep.equal(['firstName', 'lastName']);
   });
 
+  it('should be able to exclude fields via a function', function () {
+    var fields = attributeFields(Model, {
+      exclude: field => ~[
+        'id', 'email', 'char', 'float', 'decimal', 'enum',
+        'enumTwo', 'list', 'virtualInteger', 'virtualBoolean',
+        'date','time','dateonly','comment'
+      ].indexOf(field)
+    });
+
+    expect(Object.keys(fields)).to.deep.equal(['firstName', 'lastName']);
+  });
+
   it('should be possible to specify specific fields', function () {
     var fields = attributeFields(Model, {
       only: ['id', 'email', 'list']
+    });
+
+    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'list']);
+  });
+
+  it('should be possible to specify specific fields via a function', function () {
+    var fields = attributeFields(Model, {
+      only: field => ~['id', 'email', 'list'].indexOf(field),
     });
 
     expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'list']);


### PR DESCRIPTION
This modifies the `exclude` and `only` options of attributeFields to allow
functions to be passed instead of a list of arguments.

This allows more programmatic removal of fields. For example, I would like to
remove all fields that have an underscore in them (foreign keys). This would
allow me to write:

```js
{
  fields: () => ({
    ...attributeFields(Model, { exclude: field => ~field.indexOf('_') })
  })
}
```