### PR TITLE
Fix False Positive While Preserving ~ Operator

### DIFF
--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -5,13 +5,16 @@ import { globalIdField } from 'graphql-relay';
 module.exports = function (Model, options = {}) {
   var cache = options.cache || {};
   var result = Object.keys(Model.rawAttributes).reduce(function (memo, key) {
+    if (options.exclude && options.only) {
+      console.warn('Filtering by both exclude and only properties is not supported.');
+    }
     if (options.exclude) {
       if (typeof options.exclude === 'function' && options.exclude(key)) return memo;
-      if (Array.isArray(options.exclude) && !~options.exclude.indexOf(key)) return memo;
+      if (Array.isArray(options.exclude) && options.exclude.length !== 0 && ~options.exclude.indexOf(key)) return memo;
     }
     if (options.only) {
       if (typeof options.only === 'function' && !options.only(key)) return memo;
-      if (Array.isArray(options.only) && !~options.only.indexOf(key)) return memo;
+      if (Array.isArray(options.only) && options.only.length !== 0 && !~options.only.indexOf(key)) return memo;
     }
 
     var attribute = Model.rawAttributes[key]

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -7,7 +7,7 @@ module.exports = function (Model, options = {}) {
   var result = Object.keys(Model.rawAttributes).reduce(function (memo, key) {
     if (options.exclude) {
       if (typeof options.exclude === 'function' && options.exclude(key)) return memo;
-      if (Array.isArray(options.exclude) && ~options.exclude.indexOf(key)) return memo;
+      if (Array.isArray(options.exclude) && !~options.exclude.indexOf(key)) return memo;
     }
     if (options.only) {
       if (typeof options.only === 'function' && !options.only(key)) return memo;

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , Sequelize = require('sequelize')
-  , attributeFields = require('../../src/attributeFields');
-
-import { sequelize } from '../support/helper'
-
+import chai from 'chai';
+import Sequelize from 'sequelize';
+import attributeFields from '../../src/attributeFields';
+import { sequelize } from '../support/helper';
 import {
   GraphQLString,
   GraphQLInt,
@@ -23,6 +20,8 @@ import {
   toGlobalId
 } from 'graphql-relay';
 
+var expect = chai.expect;
+
 describe('attributeFields', function () {
   var Model;
   var modelName = Math.random().toString();
@@ -38,8 +37,8 @@ describe('attributeFields', function () {
       lastName: {
         type: Sequelize.STRING
       },
-      char:{
-        type:Sequelize.CHAR
+      char: {
+        type: Sequelize.CHAR
       },
       float: {
         type: Sequelize.FLOAT
@@ -62,16 +61,16 @@ describe('attributeFields', function () {
       virtualBoolean: {
         type: new Sequelize.VIRTUAL(Sequelize.BOOLEAN)
       },
-      date:{
-        type:Sequelize.DATE
+      date: {
+        type: Sequelize.DATE
       },
-      time:{
-        type:Sequelize.TIME
+      time: {
+        type: Sequelize.TIME
       },
-      dateonly:{
-        type:Sequelize.DATEONLY
+      dateonly: {
+        type: Sequelize.DATEONLY
       },
-      comment:{
+      comment: {
         type: Sequelize.STRING,
         comment: 'This is a comment'
       }
@@ -122,7 +121,7 @@ describe('attributeFields', function () {
   });
 
   it('should be possible to rename fields with a object map',function () {
-    var fields = attributeFields(Model, {map: {"id":"mappedId"}});
+    var fields = attributeFields(Model, {map: {id: 'mappedId'}});
     expect(Object.keys(fields)).to.deep.equal([
       'mappedId', 'email', 'firstName', 'lastName', 'char', 'float', 'decimal',
       'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean', 'date',
@@ -251,7 +250,7 @@ describe('attributeFields', function () {
             }
           })
         });
-      }
+      };
     };
 
     // Bad: Will create multiple/duplicate types with same name

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -164,7 +164,27 @@ describe('attributeFields', function () {
     expect(Object.keys(fields)).to.deep.equal(['firstName', 'lastName']);
   });
 
-  it('should be possible to specify specific fields', function () {
+  it('should gracefully handle empty exclude arrays', function () {
+    var fields = attributeFields(Model, {
+      exclude: []
+    });
+
+    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName',
+    'lastName', 'char', 'float', 'decimal', 'enum', 'enumTwo', 'list', 'virtualInteger',
+    'virtualBoolean','date','time','dateonly','comment']);
+  });
+
+  it('should gracefully handle empty only arrays', function () {
+    var fields = attributeFields(Model, {
+      only: []
+    });
+
+    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName',
+    'lastName', 'char', 'float', 'decimal', 'enum', 'enumTwo', 'list', 'virtualInteger',
+    'virtualBoolean','date','time','dateonly','comment']);
+  });
+
+  it('should be possible to specify fields to include in an array', function () {
     var fields = attributeFields(Model, {
       only: ['id', 'email', 'list']
     });
@@ -172,7 +192,7 @@ describe('attributeFields', function () {
     expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'list']);
   });
 
-  it('should be possible to specify specific fields via a function', function () {
+  it('should be possible to specify fields to include via a function', function () {
     var fields = attributeFields(Model, {
       only: field => ~['id', 'email', 'list'].indexOf(field),
     });


### PR DESCRIPTION
This implementation fixes the error while maintaining the `~` operator. While I'd rather remove this operator for clarity, it is used in both the helper implementation and in the tests for the helper. I was rewriting large portions of the tool and it's probably not my place to reimplement it. I instead added a check for empty arrays on lines 13 and 17 of `attributeFields.js` and added tests to ensure that future empty arrays behave as expected. I also added a warning if both `exclude` and `only` are present. The check is basic but it's better than nothing.