### PR TITLE
Order By with args

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -101,7 +101,8 @@ const userTaskConnection = sequelizeConnection({
     name: 'UserTaskOrderBy',
     values: {
       AGE: {value: ['createdAt', 'DESC']}, // The first ENUM value will be the default order. The direction will be used for `first`, will automatically be inversed for `last` lookups.
-      TITLE: {value:  ['title', 'ASC']}
+      TITLE: {value:  ['title', 'ASC']},
+      CUSTOM: {value:  [function (source, args, context, info) {}, 'ASC']} // build and return custom order for sequelize orderBy option
     }
   }),
   where: function (key, value) {

--- a/src/relay.js
+++ b/src/relay.js
@@ -150,12 +150,9 @@ export function sequelizeConnection({
 
   let orderByDirection = function (orderDirection, args) {
     if (args.last) {
-      orderDirection = orderDirection.indexOf('ASC') >= 0
+      return orderDirection.indexOf('ASC') >= 0
               ? orderDirection.replace('ASC', 'DESC')
               : orderDirection.replace('DESC', 'ASC');
-      orderDirection = orderDirection.indexOf('LAST') >= 0
-              ? orderDirection.replace('LAST', 'FIRST')
-              : orderDirection.replace('FIRST', 'LAST');
     }
     return orderDirection;
   };

--- a/src/relay.js
+++ b/src/relay.js
@@ -144,8 +144,8 @@ export function sequelizeConnection({
     }
   };
 
-  let orderByAttribute = function (orderAttr, args) {
-    return typeof orderAttr === 'function' ? orderAttr(args) : orderAttr;
+  let orderByAttribute = function (orderAttr, {source, args, context, info}) {
+    return typeof orderAttr === 'function' ? orderAttr(source, args, context, info) : orderAttr;
   };
 
   let orderByDirection = function (orderDirection, args) {
@@ -223,7 +223,12 @@ export function sequelizeConnection({
       }
 
       let orderBy = args.orderBy;
-      let orderAttribute = orderByAttribute(orderBy[0][0], args);
+      let orderAttribute = orderByAttribute(orderBy[0][0], {
+        source: info.source,
+        args,
+        context,
+        info
+      });
       let orderDirection = orderByDirection(orderBy[0][1], args);
 
       options.order = [

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -506,7 +506,7 @@ describe('relay', function () {
       `, null, {});
 
       expect(this.projectOrderSpy).to.have.been.calledOnce;
-      expect(this.projectOrderSpy.alwaysCalledWithMatch({ first: 5 })).to.be.ok;
+      expect(this.projectOrderSpy.alwaysCalledWithMatch({}, { first: 5 })).to.be.ok;
     });
 
     it('should properly reverse NULLS LAST in orderBy', async function () {

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -509,32 +509,8 @@ describe('relay', function () {
       expect(this.projectOrderSpy.alwaysCalledWithMatch({}, { first: 5 })).to.be.ok;
     });
 
-    it('should properly reverse orderBy', async function () {
+    it('should properly reverse orderBy with last', async function () {
       let sqlSpy = sinon.spy();
-      await graphql(this.schema, `
-        {
-          user(id: ${this.userA.id}) {
-            projects(first: 1) {
-              edges {
-                node {
-                  tasks(orderBy: NAME_NULLS_LAST, first: 10) {
-                    edges {
-                      cursor
-                      node {
-                        id
-                        name
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `, null, { logging: sqlSpy });
-
-      expect(sqlSpy.lastCall.args[0].match('ASC NULLS LAST')).to.be.ok;
-
       await graphql(this.schema, `
         {
           user(id: ${this.userA.id}) {

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -509,7 +509,7 @@ describe('relay', function () {
       expect(this.projectOrderSpy.alwaysCalledWithMatch({}, { first: 5 })).to.be.ok;
     });
 
-    it('should properly reverse NULLS LAST in orderBy', async function () {
+    it('should properly reverse orderBy', async function () {
       let sqlSpy = sinon.spy();
       await graphql(this.schema, `
         {

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -509,7 +509,7 @@ describe('relay', function () {
       expect(this.projectOrderSpy.alwaysCalledWithMatch({}, { first: 5 })).to.be.ok;
     });
 
-    it('should properly reverse orderBy with last', async function () {
+    it('should properly reverse orderBy with NULLS and last', async function () {
       let sqlSpy = sinon.spy();
       await graphql(this.schema, `
         {
@@ -698,7 +698,7 @@ describe('relay', function () {
     });
 
     it('should support pagination with where', async function () {
-      const completedTasks = this.userA.tasks.filter(task => task.completed)
+      const completedTasks = this.userA.tasks.filter(task => task.completed);
 
       expect(completedTasks.length).to.equal(4);
 
@@ -991,8 +991,8 @@ describe('relay', function () {
 
       const nodeNames = result.data.user.projects.edges.map(edge => {
         return edge.node.tasks.edges.map(edge => {
-          return edge.node.name
-        }).sort()
+          return edge.node.name;
+        }).sort();
       });
       expect(nodeNames).to.deep.equal([
         [

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -557,7 +557,7 @@ describe('relay', function () {
         }
       `, null, { logging: sqlSpy });
 
-      expect(sqlSpy.lastCall.args[0].match('DESC NULLS FIRST')).to.be.ok;
+      expect(sqlSpy.lastCall.args[0].match('DESC NULLS LAST')).to.be.ok;
     });
 
     it('should support in-query slicing and pagination with first and orderBy', async function () {


### PR DESCRIPTION
Sometime we require to build `orderBy` query based on `args`, with this PR this will be possible now.

If orderBY ENUM value for any field is a function, then its called with `args` and return value is used to build the query.

```js

function calledWithArgs (args) { return 'name'; };

// Order By ENUM
values: {
   NAME_FUNC: {value: [calledWithArgs, 'ASC']}
}
```

Also this PR will allow proper reversing when order direction is combination of orders like
```sql
DESC NULLS LAST
ASC NULLS LAST
```