### PR TITLE
ORDER BY multiple columns

### DIFF
--- a/src/argsToFindOptions.js
+++ b/src/argsToFindOptions.js
@@ -19,11 +19,8 @@ export default function argsToFindOptions(args, targetAttributes) {
       }
 
       if (key === 'order' && args[key]) {
-        if (args[key].indexOf('reverse:') === 0) {
-          result.order = [[args[key].substring(8), 'DESC']];
-        } else {
-          result.order = [[args[key], 'ASC']];
-        }
+        result.order = result.order || [];
+        result.order = args[key];
       }
 
       if (key === 'where' && args[key]) {

--- a/src/defaultListArgs.js
+++ b/src/defaultListArgs.js
@@ -1,4 +1,4 @@
-import { GraphQLInt, GraphQLString } from 'graphql';
+import { GraphQLList, GraphQLInt, GraphQLString } from 'graphql';
 import JSONType from './types/jsonType';
 
 module.exports = function () {
@@ -7,7 +7,7 @@ module.exports = function () {
       type: GraphQLInt
     },
     order: {
-      type: GraphQLString
+      type: new GraphQLList(new GraphQLList(GraphQLString))
     },
     where: {
       type: JSONType,

--- a/test/unit/defaultListArgs.test.js
+++ b/test/unit/defaultListArgs.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-import chai, {expect} from "chai";
-import Sequelize from "sequelize";
-import defaultListArgs from "../../src/defaultListArgs";
+import { expect } from 'chai';
+import Sequelize from 'sequelize';
+import defaultListArgs from '../../src/defaultListArgs';
 
-import { sequelize } from '../support/helper'
+import { sequelize } from '../support/helper';
 
 import {
   GraphQLString,
   GraphQLInt,
-  GraphQLNonNull,
-  GraphQLScalarType
+  GraphQLScalarType,
+  GraphQLList,
 } from 'graphql';
 
 describe('defaultListArgs', function () {
@@ -25,7 +25,7 @@ describe('defaultListArgs', function () {
     var args = defaultListArgs();
 
     expect(args).to.have.ownProperty('order');
-    expect(args.order.type).to.equal(GraphQLString);
+    expect(args.order.type).to.eql(new GraphQLList(new GraphQLList(GraphQLString)));
   });
 
   describe('will have an "where" argument', function () {


### PR DESCRIPTION
Prefer Sequelize default syntax for better performance.
Expected variables syntax of `order` key:
```
{
  "order": [
    ["createdAt", "ASC"],
    ["updatedAt", "DESC"]
  ]
}
```