### PR TITLE
Fixed before call without right arguments

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -260,7 +260,7 @@ export function sequelizeConnection({
         let cursor = fromCursor(args.after || args.before);
         let startIndex = Number(cursor.index);
 
-        if (startIndex > 0) options.offset = startIndex + 1;
+        if (startIndex >= 0) options.offset = startIndex + 1;
       }
       options.attributes = _.uniq(options.attributes);
       return before(options, args, context, info);

--- a/src/relay.js
+++ b/src/relay.js
@@ -295,9 +295,15 @@ export function sequelizeConnection({
         }, args, context, info));
 
         if (target.count) {
-          fullCount = await target.count(options);
+          // If it's a relation
+          if (target.associationType) {
+            fullCount = await target.count(source, options);
+          } else {
+            // target: Model case
+            fullCount = await target.count(options);
+          }
         } else {
-          fullCount = await target.manyFromSource.count(options);
+          fullCount = await target.manyFromSource.count(source, options);
         }
       }
 

--- a/src/relay.js
+++ b/src/relay.js
@@ -295,9 +295,9 @@ export function sequelizeConnection({
         }, args, context, info));
 
         if (target.count) {
-          fullCount = await target.count(source, options);
+          fullCount = await target.count(options);
         } else {
-          fullCount = await target.manyFromSource.count(source, options);
+          fullCount = await target.manyFromSource.count(options);
         }
       }
 

--- a/src/relay.js
+++ b/src/relay.js
@@ -196,9 +196,14 @@ export function sequelizeConnection({
   };
 
   let resolveEdge = function (item, index, queriedCursor, args = {}, source) {
-    let startIndex = 0;
+    let startIndex = false;
     if (queriedCursor) startIndex = Number(queriedCursor.index);
-    if (startIndex !== 0) startIndex++;
+    if (startIndex !== false) {
+      startIndex++;
+    } else {
+      startIndex = 0;
+    }
+
     return {
       cursor: toCursor(item, index + startIndex),
       node: item,
@@ -311,8 +316,12 @@ export function sequelizeConnection({
       let hasPreviousPage = false;
       if (args.first || args.last) {
         const count = parseInt(args.first || args.last, 10);
-        let index = cursor ? Number(cursor.index) : 0;
-        if (index !== 0) index++;
+        let index = cursor ? Number(cursor.index) : false;
+        if (index !== false) {
+          index++;
+        } else {
+          index = 0;
+        }
 
         hasNextPage = index + 1 + count <= fullCount;
         hasPreviousPage = index - count >= 0;

--- a/src/relay.js
+++ b/src/relay.js
@@ -265,7 +265,11 @@ export function sequelizeConnection({
       options.attributes = _.uniq(options.attributes);
       return before(options, args, context, info);
     },
-    after: async function (values, args, context, {source}) {
+    after: async function (values, args, context, info) {
+      const {
+        source,
+      } = info;
+
       var cursor = null;
 
       if (args.after || args.before) {
@@ -288,7 +292,7 @@ export function sequelizeConnection({
         // In case of `OVER()` is not available, we need to get the full count from a second query.
         const options = await Promise.resolve(before({
           where: argsToWhere(args)
-        }));
+        }, args, context, info));
 
         if (target.count) {
           fullCount = await target.count(source, options);

--- a/src/relay.js
+++ b/src/relay.js
@@ -196,9 +196,9 @@ export function sequelizeConnection({
   };
 
   let resolveEdge = function (item, index, queriedCursor, args = {}, source) {
-    let startIndex = false;
+    let startIndex = null;
     if (queriedCursor) startIndex = Number(queriedCursor.index);
-    if (startIndex !== false) {
+    if (startIndex !== null) {
       startIndex++;
     } else {
       startIndex = 0;
@@ -300,11 +300,9 @@ export function sequelizeConnection({
         }, args, context, info));
 
         if (target.count) {
-          // If it's a relation
           if (target.associationType) {
             fullCount = await target.count(source, options);
           } else {
-            // target: Model case
             fullCount = await target.count(options);
           }
         } else {
@@ -316,8 +314,8 @@ export function sequelizeConnection({
       let hasPreviousPage = false;
       if (args.first || args.last) {
         const count = parseInt(args.first || args.last, 10);
-        let index = cursor ? Number(cursor.index) : false;
-        if (index !== false) {
+        let index = cursor ? Number(cursor.index) : null;
+        if (index !== null) {
           index++;
         } else {
           index = 0;


### PR DESCRIPTION
`before` hook was called without args, context or info, and my `before` function depended on it.