### PR TITLE
In line with documentation

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -62,7 +62,7 @@ export function typeResolver(nodeTypeMapper) {
   return obj => {
     var type = obj.__graphqlType__
                || (obj.Model
-                 ? obj.Model.options.name.singular
+                 ? obj.Model.name
                  : obj.name);
 
     if (!type) {

--- a/src/relay.js
+++ b/src/relay.js
@@ -85,13 +85,18 @@ export function handleConnection(values, args) {
 
 export function sequelizeNodeInterface(sequelize) {
   let nodeTypeMapper = new NodeTypeMapper();
+  const myIdFetcher = idFetcher(sequelize, nodeTypeMapper);
+  const myTypeResolver = typeResolver(nodeTypeMapper);
+
   const nodeObjects = nodeDefinitions(
-    idFetcher(sequelize, nodeTypeMapper),
-    typeResolver(nodeTypeMapper)
+    myIdFetcher,
+    myTypeResolver,
   );
 
   return {
     nodeTypeMapper,
+    idFetcher: myIdFetcher,
+    typeResolver: myTypeResolver,
     ...nodeObjects
   };
 }

--- a/src/relay.js
+++ b/src/relay.js
@@ -340,7 +340,7 @@ export function sequelizeConnection({
           hasNextPage: hasNextPage,
           hasPreviousPage: hasPreviousPage
         }
-      });
+      }, args, context, info);
     }
   });
 

--- a/src/relay.js
+++ b/src/relay.js
@@ -302,7 +302,7 @@ export function sequelizeConnection({
         // In case of `OVER()` is not available, we need to get the full count from a second query.
         const options = await Promise.resolve(before({
           where: argsToWhere(args)
-        }, args, context, info));
+        }, args, context, info, true));
 
         if (target.count) {
           if (target.associationType) {


### PR DESCRIPTION
In the documentation, it is specified to use `Model.name` in `nodeTypeMapper`, but it actually takes the type from `Model.options.name.singular`, which led me to an error when trying to query the `node` field.