### PR TITLE
remove redundant eslint rule breaking build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,6 @@
     "no-empty-character-class": 2,
     "no-ex-assign": 2,
     "no-extra-boolean-cast": 2,
-    "no-extra-parens": 0,
     "no-extra-semi": 2,
     "no-func-assign": 2,
     "no-inner-declarations": [


### PR DESCRIPTION
I kept the newest definition, which sets `no-extra-parens` to 2.