### PR TITLE
argsToWhere where(key, value) -> where(key, value, previousWhere)

### DIFF
--- a/docs/relay.md
+++ b/docs/relay.md
@@ -105,7 +105,7 @@ const userTaskConnection = sequelizeConnection({
       CUSTOM: {value:  [function (source, args, context, info) {}, 'ASC']} // build and return custom order for sequelize orderBy option
     }
   }),
-  where: function (key, value) {
+  where: function (key, value, currentWhere) {
     // for custom args other than connectionArgs return a sequelize where parameter
 
     return {[key]: value};

--- a/src/relay.js
+++ b/src/relay.js
@@ -189,7 +189,7 @@ export function sequelizeConnection({
 
     _.each(args, (value, key) => {
       if (key in $connectionArgs) return;
-      _.assign(result, where(key, value));
+      _.assign(result, where(key, value, result));
     });
 
     return result;

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -158,7 +158,7 @@ describe('relay', function () {
             return {
               createdAt: {
                 ...existingWhere,
-                gte: new Date(now - 35000)
+                gte: new Date(now - 36000)
               }
             };
           }
@@ -167,7 +167,7 @@ describe('relay', function () {
             return {
               createdAt: {
                 ...existingWhere,
-                lte: new Date(now - 25000)
+                lte: new Date(now - 24000)
               }
             };
           }

--- a/test/integration/relay/connection.test.js
+++ b/test/integration/relay/connection.test.js
@@ -851,7 +851,7 @@ describe('relay', function () {
       ]);
     });
 
-    it.only('should support multiple user provided args/where that act on a single database field', async function () {
+    it('should support multiple user provided args/where that act on a single database field', async function () {
       let result = await graphql(this.schema, `
         {
           user(id: ${this.userA.id}) {

--- a/test/unit/relay/connection.test.js
+++ b/test/unit/relay/connection.test.js
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 import {expect} from 'chai';
 import sinon from 'sinon';
-import { sequelize } from '../../support/helper'
+import { sequelize } from '../../support/helper';
 import attributeFields from '../../../src/attributeFields';
 
 import {


### PR DESCRIPTION
The where(key, value) is run for each custom arg to generate the proper
where statement for that arg.

The issue is that if two arguments interact with the same field, the
second one will overwrite the first when it is assigned to the previous
where.
e.g. You have a sampleFieldGreaterThan arg and a sampleFieldLessThan
arg. You might fill out both if you are doing a range. The second one
would overwrite the first.

The simple fix: pass the previous where values to the function so you
can perform merging logic or any other complex logic inside the where.