### PR TITLE
Handle an array of order options for dynamic filters

### DIFF
--- a/src/argsToFindOptions.js
+++ b/src/argsToFindOptions.js
@@ -19,7 +19,9 @@ export default function argsToFindOptions(args, targetAttributes) {
       }
 
       if (key === 'order' && args[key]) {
-        if (args[key].indexOf('reverse:') === 0) {
+        if (Array.isArray(args[key]) ) {
+          result.order = args[key];
+        } else if (args[key].indexOf('reverse:') === 0) {
           result.order = [[args[key].substring(8), 'DESC']];
         } else {
           result.order = [[args[key], 'ASC']];

--- a/test/unit/argsToFindOptions.test.js
+++ b/test/unit/argsToFindOptions.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var chai = require('chai')
+  , expect = chai.expect
+  , Sequelize = require('sequelize')
+  , attributeFields = require('../../src/attributeFields');
+
+import { sequelize } from '../support/helper'
+
+import argsToFindOptions from "../../src/argsToFindOptions";
+
+
+describe("order options", ()=> {
+  let sequalizeOrder = {
+    order: [['name','ASC']]
+  }
+
+  it("preserve order args as sequalize-like order options array", ()=> {
+    let result = argsToFindOptions(sequalizeOrder, [])
+    expect(result).to.eql(sequalizeOrder)
+  });
+
+  it("order args as simple string adds sort direction", ()=> {
+
+    let args = { order: 'name' }
+
+    let result = argsToFindOptions(args, [])
+    expect(result).to.eql(sequalizeOrder)
+  });
+
+});


### PR DESCRIPTION
This change will simply pass through order options to sequalize, allowing for multiple columns to be handled. 

```
{
  order: {
    type: new GraphQLList( new GraphQLList(GraphQLString) ),
    description: 'A JSON object conforming the the shape specified in http://docs.sequelizejs.com/en/latest/docs/querying/#ordering'
  }
}
```