### PR TITLE
add relay connection fullCount data to after hook

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -339,7 +339,8 @@ export function sequelizeConnection({
           endCursor: lastEdge ? lastEdge.cursor : null,
           hasNextPage: hasNextPage,
           hasPreviousPage: hasPreviousPage
-        }
+        },
+        fullCount
       }, args, context, info);
     }
   });

--- a/test/unit/relay/connection.test.js
+++ b/test/unit/relay/connection.test.js
@@ -119,7 +119,9 @@ describe('relay', function () {
       );
 
       expect(this.afterSpy).to.have.been.calledWithMatch(
-        sinon.match.any,
+        sinon.match({
+          fullCount: sinon.match.number
+        }),
         sinon.match({
           orderBy: sinon.match.any
         }),


### PR DESCRIPTION
Hi mickhansen,

as we discussed in #417 here is my shot on propagating fullCount info to the after hook of a relay connection. I tried to extend the testcase too, but I'm not sure if it is the right place.

I don't think any of the existing docs have to be updated for this, because the data passed to the after hook doesn't seem to be documented.

Sorry that it took me a while, but you know how it is :)

Feel free to give me feedback.

regards
Hannes