### PR TITLE
Expose argsToFindOptions in the API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  argsToFindOptions: require('./argsToFindOptions'),
   resolver: require('./resolver'),
   defaultListArgs: require('./defaultListArgs'),
   defaultArgs: require('./defaultArgs'),
@@ -6,5 +7,5 @@ module.exports = {
   attributeFields: require('./attributeFields'),
   simplifyAST: require('./simplifyAST'),
   relay: require('./relay'),
-  JSONType: require('./types/jsonType')
+  JSONType: require('./types/jsonType'),
 };


### PR DESCRIPTION
I just found myself in need of using `argsToFindOptions` in my app so I think it is relevant to expose it as well through the API.
Great work!