### PR TITLE
Upgrade peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "graphql-relay": "^0.4.2",
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
+    "graphql-relay": "^0.4.2 || ^0.5.0",
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
`peerDependencies` need to be upgraded because they cause warning in projects since newer versions of `graphql` and `graphql-relay` were recently releases.