### PR TITLE
Fix EnumType name missing error with GraphQL ^0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint": "^1.7.3",
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
-    "graphql": "^0.9.3",
+    "graphql": "^0.7.0",
     "graphql-relay": "^0.4.3",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "graphql-relay": "^0.4.2",
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0",
+    "graphql-relay": "^0.4.2"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -61,7 +61,7 @@
     "eslint": "^1.7.3",
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
-    "graphql": "^0.7.0",
+    "graphql": "^0.9.3",
     "graphql-relay": "^0.4.3",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.0",

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -27,7 +27,7 @@ module.exports = function (Model, options = {}) {
     }
 
     memo[key] = {
-      type: typeMapper.toGraphQL(type, Model.sequelize.constructor)
+      type: typeMapper.toGraphQL(type, Model.sequelize.constructor, Model)
     };
 
     if (memo[key].type instanceof GraphQLEnumType ) {

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -27,11 +27,11 @@ module.exports = function (Model, options = {}) {
     }
 
     memo[key] = {
-      type: typeMapper.toGraphQL(type, Model.sequelize.constructor, Model)
+      type: typeMapper.toGraphQL(type, Model.sequelize.constructor, { name: `${Model.name}${key}`})
     };
 
     if (memo[key].type instanceof GraphQLEnumType ) {
-      var typeName = `${Model.name}${key}EnumType`;
+      var typeName = memo[key].type.name;
       /*
       Cache enum types to prevent duplicate type name error
       when calling attributeFields multiple times on the same model

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -24,7 +24,7 @@ export function mapType(mapFunc) {
  * @param  {Object} sequelizeTypes
  * @return {Function} GraphQL type declaration
  */
-export function toGraphQL(sequelizeType, sequelizeTypes) {
+export function toGraphQL(sequelizeType, sequelizeTypes, Model) {
 
   // did the user supply a mapping function?
   // use their mapping, if it returns truthy
@@ -99,7 +99,8 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
         }
         obj[sanitizedValue] = {value};
         return obj;
-      }, {})
+      }, {}),
+      name: Model.name,
     });
   }
 

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -24,7 +24,7 @@ export function mapType(mapFunc) {
  * @param  {Object} sequelizeTypes
  * @return {Function} GraphQL type declaration
  */
-export function toGraphQL(sequelizeType, sequelizeTypes, Model) {
+export function toGraphQL(sequelizeType, sequelizeTypes, Model = {}) {
 
   // did the user supply a mapping function?
   // use their mapping, if it returns truthy

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -24,7 +24,7 @@ export function mapType(mapFunc) {
  * @param  {Object} sequelizeTypes
  * @return {Function} GraphQL type declaration
  */
-export function toGraphQL(sequelizeType, sequelizeTypes, Model = {}) {
+export function toGraphQL(sequelizeType, sequelizeTypes, opts = {}) {
 
   // did the user supply a mapping function?
   // use their mapping, if it returns truthy
@@ -100,7 +100,7 @@ export function toGraphQL(sequelizeType, sequelizeTypes, Model = {}) {
         obj[sanitizedValue] = {value};
         return obj;
       }, {}),
-      name: Model.name,
+      name: `${opts.name}EnumType`,
     });
   }
 

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -25,7 +25,7 @@ import {
 
 describe('attributeFields', function () {
   var Model;
-  var modelName = Math.random().toString(36).slice(2);
+  var modelName = 'model' + Math.random().toString().slice(2);
   before(function () {
     Model = sequelize.define(modelName, {
       email: {

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -25,7 +25,7 @@ import {
 
 describe('attributeFields', function () {
   var Model;
-  var modelName = Math.random().toString();
+  var modelName = Math.random().toString(36).slice(2);
   before(function () {
     Model = sequelize.define(modelName, {
       email: {

--- a/test/unit/typeMapper.test.js
+++ b/test/unit/typeMapper.test.js
@@ -109,7 +109,11 @@ describe('typeMapper', () => {
 
   describe('ENUM', function () {
     it('should map to instance of GraphQLEnumType', function () {
-      expect(toGraphQL(new ENUM('value', 'another value'), Sequelize)).to.instanceof(GraphQLEnumType);
+      expect(
+        toGraphQL(new ENUM('value', 'another value'),
+        Sequelize,
+        { name: 'EnumTypeName' },
+      )).to.instanceof(GraphQLEnumType);
     });
   });
 


### PR DESCRIPTION
If using with GraphQL ^0.9.0, Enum fields will throw this error:

```
Error: Must be named. Unexpected name: undefined.
    at assertValidName (node_modules/graphql/utilities/assertValidName.js:29:11)
    at new GraphQLEnumType (node_modules/graphql/type/definition.js:509:42)
    at Object.toGraphQL (node_modules/graphql-sequelize/lib/typeMapper.js:76:12)
    at node_modules/graphql-sequelize/lib/attributeFields.js:39:24
    at Array.reduce (native)
    at module.exports (node_modules/graphql-sequelize/lib/attributeFields.js:17:49)
```

This PR will fix that.