### PR TITLE
[WIP] Fix v4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mysql": "^2.11.1",
     "pg": "^5.0.0",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^4.0.0",
+    "sequelize": "^3.24.6",
     "sinon": "^1.15.4",
     "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/mickhansen/graphql-sequelize",
   "dependencies": {
-    "dataloader-sequelize": "github:chez-nestor/dataloader-sequelize#track_lib",
+    "dataloader-sequelize": "^1.4.6",
     "invariant": "2.2.1",
     "bluebird": "^3.4.0",
     "lodash": "^4.0.0"
@@ -70,7 +70,7 @@
     "mysql": "^2.11.1",
     "pg": "^5.0.0",
     "pg-hstore": "^2.3.2",
-    "sequelize": "github:sequelize/sequelize#master",
+    "sequelize": "^4.0.0",
     "sinon": "^1.15.4",
     "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
   },
   "homepage": "https://github.com/mickhansen/graphql-sequelize",
   "dependencies": {
-    "dataloader-sequelize": "^1.4.5",
+    "dataloader-sequelize": "github:chez-nestor/dataloader-sequelize#track_lib",
     "invariant": "2.2.1",
     "bluebird": "^3.4.0",
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
     "graphql-relay": "^0.4.2 || ^0.5.0",
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -62,7 +62,7 @@
     "eslint": "^1.7.3",
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
-    "graphql": "^0.9.0",
+    "graphql": "^0.10.1",
     "graphql-relay": "^0.4.3",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.0",
@@ -70,7 +70,7 @@
     "mysql": "^2.11.1",
     "pg": "^5.0.0",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^3.24.6",
+    "sequelize": "github:sequelize/sequelize#master",
     "sinon": "^1.15.4",
     "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0",

--- a/src/relay.js
+++ b/src/relay.js
@@ -63,6 +63,8 @@ export function typeResolver(nodeTypeMapper) {
     var type = obj.__graphqlType__
                || (obj.Model
                  ? obj.Model.options.name.singular
+                 : obj._modelOptions
+                 ? obj._modelOptions.name.singular
                  : obj.name);
 
     if (!type) {


### PR DESCRIPTION
Hi there!

I'm trying to make this lib compatible with Sequelize v4. This proved to be very little work compared to fixing dataloader-sequelize.
This PR contains changes to package.json that points to my fork of dataloader-sequelize. Once https://github.com/mickhansen/dataloader-sequelize/pull/31 is merged, I can change this PR to point to the regular package on npm.
(I also have a fork where lib/ has been commited to the repo, for convenience: https://github.com/chez-nestor/graphql-sequelize/tree/track_lib ).

I have yet to test the lib on a large project. I'll fix remaining bugs as I find them.
Please let me know if you feel something might be missing.