### PR TITLE
Don't overwrite name of enum type if it already exists

### DIFF
--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -39,7 +39,7 @@ module.exports = function (Model, options = {}) {
       if (cache[typeName]) {
         memo[key].type = cache[typeName];
       } else {
-        memo[key].type.name = typeName;
+        if (memo[key].type.name === 'tempEnumName') memo[key].type.name = typeName;
         cache[typeName] = memo[key].type;
       }
 


### PR DESCRIPTION
If a custom typeMapper already returns a custom enum type, attributeFields would overwrite that type's name with its own version, causing all sorts of problems (such as duplicated enum type definitions in the schema, which relay-compiler 1.1 does not like at all).