### PR TITLE
fix crash if enum starts with a digit or has two consequent illegal symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,16 @@ attributeFields(Model, {
 
 ### ENUM attributes with non-alphanumeric characters
 
-GraphQL enum types [only support ASCII alphanumeric characters and underscores](https://facebook.github.io/graphql/#Name).
+GraphQL enum types [only support ASCII alphanumeric characters, digits and underscores with leading non-digit](https://facebook.github.io/graphql/#Name).
 If you have other characters, like a dash (`-`) in your Sequelize enum types,
-they will be converted to camelCase. For example: `foo-bar` becomes `fooBar`.
+they will be converted to camelCase. If your enum value starts from a digit, it
+will be prepended with an underscore.
+
+For example: 
+
+- `foo-bar` becomes `fooBar` 
+
+- `25.8` becomes `_258`
 
 ### VIRTUAL attributes and GraphQL fields
 

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -7,6 +7,7 @@ import {
    GraphQLList
  } from 'graphql';
 import JSONType from './types/jsonType';
+import _ from 'lodash';
 
 let customTypeMapper;
 /**
@@ -89,21 +90,10 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
   if (sequelizeType instanceof ENUM) {
     return new GraphQLEnumType({
       name: 'tempEnumName',
-      values: sequelizeType.values.reduce((obj, value) => {
-        let sanitizedValue = value;
-        if (specialChars.test(value)) {
-          sanitizedValue = value.split(specialChars).reduce((reduced, val, idx) => {
-            let newVal = val;
-            if (idx === 1 && /\d/.test(reduced[0])) {
-              reduced = `_${reduced}`;
-            }
-            newVal = val && `${val[0].toUpperCase()}${val.slice(1)}`;
-            return `${reduced}${newVal}`;
-          });
-        }
-        obj[sanitizedValue] = {value};
-        return obj;
-      }, {})
+      values: _(sequelizeType.values)
+        .mapKeys(sanitizeEnumValue)
+        .mapValues(v => ({value: v}))
+        .value()
     });
   }
 
@@ -120,4 +110,11 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
 
   throw new Error(`Unable to convert ${sequelizeType.key || sequelizeType.toSql()} to a GraphQL type`);
 
+  function sanitizeEnumValue(value) {
+    return value
+      .replace(/(^\d)/, '_$1')
+      .split(specialChars)
+      .map((v, i) => i ? _.upperFirst(v) : v)
+      .join('');
+  }
 }

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -94,9 +94,10 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
         if (specialChars.test(value)) {
           sanitizedValue = value.split(specialChars).reduce((reduced, val, idx) => {
             let newVal = val;
-            if (idx > 0) {
-              newVal = `${val[0].toUpperCase()}${val.slice(1)}`;
+            if (idx === 1 && /\d/.test(reduced[0])) {
+              reduced = `_${reduced}`;
             }
+            newVal = val && `${val[0].toUpperCase()}${val.slice(1)}`;
             return `${reduced}${newVal}`;
           });
         }

--- a/test/unit/typeMapper.test.js
+++ b/test/unit/typeMapper.test.js
@@ -112,7 +112,7 @@ describe('typeMapper', () => {
 
   describe('ENUM', function () {
     it('should map to instance of GraphQLEnumType', function () {
-      expect(toGraphQL(new ENUM('value', 'another value'), Sequelize)).to.instanceof(GraphQLEnumType);
+      expect(toGraphQL(new ENUM('value', 'another value', 'two--specials', '25.8'), Sequelize)).to.instanceof(GraphQLEnumType);
     });
   });
 


### PR DESCRIPTION
Examples of enum values that crashes now are `'22'` and `'foo--bar'`. This will fix it