### PR TITLE
Improve where

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,24 @@ defaultArgs(Model);
 */
 ```
 
+If you would like to pass "where" as a query variable - you should pass it as a JSON string and declear it's type as SequelizeJSON:
+
+```
+/* with GraphiQL */
+// request
+query($where: SequelizeJSON) {
+  user(where: $where) {
+    name
+  }
+}
+
+// qyery variables
+# because you can't use single quotes you need to escape JSON's the double quotes
+{
+  "where": "{\"name\": {\"like\": \"Henry%\"}}"
+}
+```
+
 ### defaultListArgs
 
 `defaultListArgs` will return an object like:

--- a/src/types/jsonType.js
+++ b/src/types/jsonType.js
@@ -5,6 +5,7 @@ import {
   GraphQLBoolean,
   GraphQLString
 } from 'graphql';
+import _ from 'lodash';
 
 import { Kind } from 'graphql/language';
 
@@ -36,6 +37,16 @@ const astToJson = {
       obj[field.name.value] = JSONType.parseLiteral(field.value);
     });
     return obj;
+  },
+  [Kind.VARIABLE](ast) {
+    /*
+    this way converted query variables would be easily
+    converted to actual values in the resolver.js by just
+    passing the query variables object in to function below.
+    We can`t convert them just in here because query variables
+    are not accessible from GraphQLScalarType's parseLiteral method
+    */
+    return _.property(ast.name.value);
   }
 };
 

--- a/src/types/jsonType.js
+++ b/src/types/jsonType.js
@@ -44,7 +44,7 @@ const JSONType = new GraphQLScalarType({
   name: 'SequelizeJSON',
   description: 'The `JSON` scalar type represents raw JSON as values.',
   serialize: value => value,
-  parseValue: value => value,
+  parseValue: value => JSON.parse(value),
   parseLiteral: ast => {
     const parser = astToJson[ast.kind];
     return parser ? parser.call(this, ast) : null;

--- a/test/integration/resolver.test.js
+++ b/test/integration/resolver.test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import Sequelize from 'sequelize';
 
 import resolver from '../../src/resolver';
+import JSONType from '../../src/types/jsonType';
 
 import {
   graphql,
@@ -219,6 +220,9 @@ describe('resolver', function () {
               },
               order: {
                 type: GraphQLString
+              },
+              where: {
+                type: JSONType
               }
             },
             resolve: resolver(User)
@@ -1121,6 +1125,23 @@ describe('resolver', function () {
       if (result.errors) throw new Error(result.errors[0].stack);
 
       expect(result.data.user.tasksByIds.length).to.equal(1);
+    });
+  });
+
+  it('should resolve query variables inside where parameter', function () {
+    return graphql(schema, `
+      query($where: SequelizeJSON) {
+        users(where: $where) {
+          id
+        }
+      }
+    `, undefined, undefined, {
+      where: '{"name": {"like": "a%"}}',
+    }).then(function (result) {
+      if (result.errors) throw new Error(result.errors[0].stack);
+
+      expect(result.data.users[0].id).to.equal(2);
+      expect(result.data.users.length).to.equal(1);
     });
   });
 });

--- a/test/integration/resolver.test.js
+++ b/test/integration/resolver.test.js
@@ -1144,4 +1144,19 @@ describe('resolver', function () {
       expect(result.data.users.length).to.equal(1);
     });
   });
+
+  it('should resolve query variables inside where parameter', function () {
+    return graphql(schema, `
+      query($name: String) {
+        users(where: {name: {like: $name}}) {
+          id
+        }
+      }
+    `, undefined, undefined, {name: 'a%'}).then(function (result) {
+      if (result.errors) throw new Error(result.errors[0].stack);
+
+      expect(result.data.users[0].id).to.equal(2);
+      expect(result.data.users.length).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
This pull request addresses two issues:
1. It was impossible to pass "where" as query variable. Now supported in form of JSON string
2. It was impossible to pass parmeters inside "where" as query variables https://github.com/mickhansen/graphql-sequelize/issues/468. Now it can be done

