### PR TITLE
ENUM special characters translation map support

### DIFF
--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -56,10 +56,12 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
     JSON
   } = sequelizeTypes;
 
-
-
-  // Regex for finding special characters
-  const specialChars = /[^a-z\d_]/i;
+  // Map of special characters
+  const specialCharsMap = new Map([
+    ['¼', 'frac14']
+    , ['½', 'frac12']
+    , ['¾', 'frac34']
+  ]);
 
   if (sequelizeType instanceof BOOLEAN) return GraphQLBoolean;
 
@@ -112,9 +114,11 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
 
   function sanitizeEnumValue(value) {
     return value
-      .replace(/(^\d)/, '_$1')
-      .split(specialChars)
+      .trim()
+      .replace(/([^_a-zA-Z0-9])/g, (_, p) => specialCharsMap.get(p) || ' ')
+      .split(' ')
       .map((v, i) => i ? _.upperFirst(v) : v)
-      .join('');
+      .join('')
+      .replace(/(^\d)/, '_$1');
   }
 }

--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -58,9 +58,9 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
 
   // Map of special characters
   const specialCharsMap = new Map([
-    ['¼', 'frac14']
-    , ['½', 'frac12']
-    , ['¾', 'frac34']
+    ['¼', 'frac14'],
+    ['½', 'frac12'],
+    ['¾', 'frac34']
   ]);
 
   if (sequelizeType instanceof BOOLEAN) return GraphQLBoolean;

--- a/test/unit/attributeFields.test.js
+++ b/test/unit/attributeFields.test.js
@@ -49,8 +49,8 @@ describe('attributeFields', function () {
       enum: {
         type: Sequelize.ENUM('first', 'second')
       },
-      enumTwo: {
-        type: Sequelize.ENUM('foo_bar', 'foo-bar')
+      enumSpecial: {
+        type: Sequelize.ENUM('foo_bar', 'foo-bar', '25.8', 'two--specials', '¼', ' ¼--½_¾ - ')
       },
       list: {
         type: Sequelize.ARRAY(Sequelize.STRING)
@@ -82,10 +82,13 @@ describe('attributeFields', function () {
   it('should return fields for a simple model', function () {
     var fields = attributeFields(Model);
 
-
-    expect(Object.keys(fields)).to.deep.equal(['id', 'email', 'firstName', 'lastName', 'char', 'float', 'decimal', 'enum',
-        'enumTwo', 'list', 'virtualInteger', 'virtualBoolean','date','time','dateonly','comment']);
-
+    expect(Object.keys(fields)).to.deep.equal([
+      'id', 'email', 'firstName', 'lastName',
+      'char', 'float', 'decimal',
+      'enum', 'enumSpecial',
+      'list', 'virtualInteger', 'virtualBoolean',
+      'date', 'time', 'dateonly', 'comment'
+    ]);
 
     expect(fields.id.type).to.be.an.instanceOf(GraphQLNonNull);
     expect(fields.id.type.ofType).to.equal(GraphQLInt);
@@ -101,7 +104,7 @@ describe('attributeFields', function () {
 
     expect(fields.enum.type).to.be.an.instanceOf(GraphQLEnumType);
 
-    expect(fields.enumTwo.type).to.be.an.instanceOf(GraphQLEnumType);
+    expect(fields.enumSpecial.type).to.be.an.instanceOf(GraphQLEnumType);
 
     expect(fields.list.type).to.be.an.instanceOf(GraphQLList);
 
@@ -124,7 +127,8 @@ describe('attributeFields', function () {
     var fields = attributeFields(Model, {map: {id: 'mappedId'}});
     expect(Object.keys(fields)).to.deep.equal([
       'mappedId', 'email', 'firstName', 'lastName', 'char', 'float', 'decimal',
-      'enum', 'enumTwo', 'list', 'virtualInteger', 'virtualBoolean', 'date',
+      'enum', 'enumSpecial',
+      'list', 'virtualInteger', 'virtualBoolean', 'date',
       'time', 'dateonly', 'comment'
     ]);
   });
@@ -135,7 +139,8 @@ describe('attributeFields', function () {
     });
     expect(Object.keys(fields)).to.deep.equal([
       'ids', 'emails', 'firstNames', 'lastNames', 'chars', 'floats', 'decimals',
-      'enums', 'enumTwos', 'lists', 'virtualIntegers', 'virtualBooleans',
+      'enums', 'enumSpecials',
+      'lists', 'virtualIntegers', 'virtualBooleans',
       'dates', 'times', 'dateonlys', 'comments'
     ]);
   });
@@ -143,8 +148,9 @@ describe('attributeFields', function () {
   it('should be possible to exclude fields', function () {
     var fields = attributeFields(Model, {
       exclude: [
-        'id', 'email', 'char', 'float', 'decimal', 'enum',
-        'enumTwo', 'list', 'virtualInteger', 'virtualBoolean',
+        'id', 'email', 'char', 'float', 'decimal',
+        'enum', 'enumSpecial',
+        'list', 'virtualInteger', 'virtualBoolean',
         'date','time','dateonly','comment'
       ]
     });
@@ -155,8 +161,9 @@ describe('attributeFields', function () {
   it('should be able to exclude fields via a function', function () {
     var fields = attributeFields(Model, {
       exclude: field => ~[
-        'id', 'email', 'char', 'float', 'decimal', 'enum',
-        'enumTwo', 'list', 'virtualInteger', 'virtualBoolean',
+        'id', 'email', 'char', 'float', 'decimal',
+        'enum', 'enumSpecial',
+        'list', 'virtualInteger', 'virtualBoolean',
         'date','time','dateonly','comment'
       ].indexOf(field)
     });
@@ -196,26 +203,38 @@ describe('attributeFields', function () {
     var fields = attributeFields(Model);
 
     expect(fields.enum.type.name).to.not.be.undefined;
-    expect(fields.enumTwo.type.name).to.not.be.undefined;
+    expect(fields.enumSpecial.type.name).to.not.be.undefined;
 
     expect(fields.enum.type.name).to.equal(modelName + 'enum' + 'EnumType');
-    expect(fields.enumTwo.type.name).to.equal(modelName + 'enumTwo' + 'EnumType');
+    expect(fields.enumSpecial.type.name).to.equal(modelName + 'enumSpecial' + 'EnumType');
   });
 
   it('should support enum values with characters not allowed by GraphQL', function () {
-    var fields = attributeFields(Model);
+    const fields = attributeFields(Model);
+    const enums = fields.enumSpecial.type.getValues();
 
-    expect(fields.enumTwo.type.getValues()).to.not.be.undefined;
-    expect(fields.enumTwo.type.getValues()[1].name).to.equal('fooBar');
-    expect(fields.enumTwo.type.getValues()[1].value).to.equal('foo-bar');
+    expect(enums).to.not.be.undefined;
+    expect(enums[0].name).to.equal('foo_bar');
+    expect(enums[0].value).to.equal('foo_bar');
+    expect(enums[1].name).to.equal('fooBar');
+    expect(enums[1].value).to.equal('foo-bar');
+    expect(enums[2].name).to.equal('_258');
+    expect(enums[2].value).to.equal('25.8');
+    expect(enums[3].name).to.equal('twoSpecials');
+    expect(enums[3].value).to.equal('two--specials');
+    expect(enums[4].name).to.equal('frac14');
+    expect(enums[4].value).to.equal('¼');
+    expect(enums[5].name).to.equal('frac14Frac12_frac34');
+    expect(enums[5].value).to.equal(' ¼--½_¾ - ');
   });
 
   it('should support enum values with underscores', function () {
-    var fields = attributeFields(Model);
+    const fields = attributeFields(Model);
+    const enums = fields.enumSpecial.type.getValues();
 
-    expect(fields.enumTwo.type.getValues()).to.not.be.undefined;
-    expect(fields.enumTwo.type.getValues()[0].name).to.equal('foo_bar');
-    expect(fields.enumTwo.type.getValues()[0].value).to.equal('foo_bar');
+    expect(enums).to.not.be.undefined;
+    expect(enums[0].name).to.equal('foo_bar');
+    expect(enums[0].value).to.equal('foo_bar');
   });
 
   it('should not create multiple enum types with same name when using cache', function () {

--- a/test/unit/typeMapper.test.js
+++ b/test/unit/typeMapper.test.js
@@ -112,7 +112,22 @@ describe('typeMapper', () => {
 
   describe('ENUM', function () {
     it('should map to instance of GraphQLEnumType', function () {
-      expect(toGraphQL(new ENUM('value', 'another value', 'two--specials', '25.8'), Sequelize)).to.instanceof(GraphQLEnumType);
+      expect(
+        toGraphQL(
+          new ENUM(
+            'value',
+            'another value',
+            'two--specials',
+            '25.8',
+            '¼',
+            '¼½',
+            '¼ ½',
+            '¼_½',
+            ' ¼--½_¾ - '
+          )
+          , Sequelize
+        )
+      ).to.instanceof(GraphQLEnumType);
     });
   });
 


### PR DESCRIPTION
This patch adds support for special characters such as ¼ in ENUM data types. These special characters are translated to their HTML entity names.