### PR TITLE
fieldASTs -> fieldNodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-sequelize",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "GraphQL & Relay for MySQL & Postgres via Sequelize",
   "main": "lib/index.js",
   "options": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "graphql-relay": "^0.4.2",
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0"
+    "graphql-relay": "^0.4.2 || ^0.5.0",
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -57,8 +57,8 @@
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "eslint": "^1.7.3",
-    "graphql": "^0.6.0",
-    "graphql-relay": "^0.4.2",
+    "graphql": "^0.11.0",
+    "graphql-relay": "^0.5.3",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.5",
     "mysql": "^2.11.1",

--- a/src/relay.js
+++ b/src/relay.js
@@ -315,7 +315,8 @@ export function sequelizeConnection({
   });
 
   let resolver = (source, args, context, info) => {
-    if (simplifyAST(info.fieldASTs[0], info).fields.edges) {
+    const fieldASTs = info.fieldNodes || info.fieldASTs;
+    if (simplifyAST(fieldASTs[0], info).fields.edges) {
       return $resolver(source, args, context, info);
     }
 

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -37,7 +37,8 @@ function resolverFactory(target, options) {
   validateOptions(options);
 
   resolver = function (source, args, context, info) {
-    var ast = info.fieldASTs
+    // fieldASTs
+    var ast = info.fieldNodes || info.fieldASTs
       , type = info.returnType
       , list = options.list || type instanceof GraphQLList
       , simpleAST = simplifyAST(ast, info)


### PR DESCRIPTION
This commit changed `info.fieldASTs` to `info.fieldNodes`: https://github.com/graphql/graphql-js/commit/e49df4980396ed40d9b43bad738c53e001d8f0e5#diff-15f6b6c92ff954f80995d31726f89851

In this branch, I've made `graphql-sequelize` v2.4 support both.