### PR TITLE
Add fieldConfig property to sequelizeConnection return value

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -366,6 +366,11 @@ export function sequelizeConnection({
     nodeType,
     resolveEdge,
     connectionArgs: $connectionArgs,
-    resolve: resolver
+    resolve: resolver,
+    fieldConfig: {
+      type: connectionType,
+      args: $connectionArgs,
+      resolve: resolver
+    }
   };
 }


### PR DESCRIPTION
Now instead of wasting keystrokes with
```js
    tasks: {
      type: userTaskConnection.connectionType,
      args: userTaskConnection.connectionArgs,
      resolve: userTaskConnection.resolve
    }
```
You can just write
```js
  tasks: userTaskConnection.fieldConfig
```