### PR TITLE
cast enum value to string

### DIFF
--- a/src/typeMapper.js
+++ b/src/typeMapper.js
@@ -118,6 +118,7 @@ export function toGraphQL(sequelizeType, sequelizeTypes) {
 
   function sanitizeEnumValue(value) {
     return value
+      .toString()
       .trim()
       .replace(/([^_a-zA-Z0-9])/g, (_, p) => specialCharsMap.get(p) || ' ')
       .split(' ')


### PR DESCRIPTION
As per https://graphql.org/graphql-js/type/#graphqlenumtype, enum values can be of any type, often integers, thus requiring a cast to string type to trim/replace/split. Without this cast, integer values raise a `TypeError: value.trim is not a function`.

As per GraphQL docs:
```graphql
class GraphQLEnumType {
  constructor(config: GraphQLEnumTypeConfig)
}

type GraphQLEnumTypeConfig = {
  name: string;
  values: GraphQLEnumValueConfigMap;
  description?: ?string;
}

type GraphQLEnumValueConfigMap = {
  [valueName: string]: GraphQLEnumValueConfig;
};

type GraphQLEnumValueConfig = {
  value?: any;
  deprecationReason?: string;
  description?: ?string;
}

type GraphQLEnumValueDefinition = {
  name: string;
  value?: any;
  deprecationReason?: string;
  description?: ?string;
```

> GraphQL serializes Enum values as strings, however internally Enums can be represented by any kind of type, often integers.

Example given by the docs:
```javascript
var RGBType = new GraphQLEnumType({
  name: 'RGB',
  values: {
    RED: { value: 0 },
    GREEN: { value: 1 },
    BLUE: { value: 2 }
  }
});
```