### PR TITLE
implemented checkDefaults option

### DIFF
--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -46,7 +46,8 @@ module.exports = function (Model, options = {}) {
     }
 
     if (!options.allowNull) {
-      if ((!options.checkDefaults || typeof attribute.defaultValue == "undefined") && (attribute.allowNull === false || attribute.primaryKey === true)) {
+      if ((!options.checkDefaults || typeof attribute.defaultValue === 'undefined') 
+          && (attribute.allowNull === false || attribute.primaryKey === true)) {
         memo[key].type = new GraphQLNonNull(memo[key].type);
       }
     }

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -46,7 +46,7 @@ module.exports = function (Model, options = {}) {
     }
 
     if (!options.allowNull) {
-      if ((!options.checkDefaults || typeof attribute.defaultValue === 'undefined') 
+      if ((!options.checkDefaults || typeof attribute.defaultValue === 'undefined')
           && (attribute.allowNull === false || attribute.primaryKey === true)) {
         memo[key].type = new GraphQLNonNull(memo[key].type);
       }

--- a/src/attributeFields.js
+++ b/src/attributeFields.js
@@ -46,7 +46,7 @@ module.exports = function (Model, options = {}) {
     }
 
     if (!options.allowNull) {
-      if (attribute.allowNull === false || attribute.primaryKey === true) {
+      if ((!options.checkDefaults || typeof attribute.defaultValue == "undefined") && (attribute.allowNull === false || attribute.primaryKey === true)) {
         memo[key].type = new GraphQLNonNull(memo[key].type);
       }
     }


### PR DESCRIPTION
it allows attributeFields to skip  GraphQLNonNull wrapping when default value exists on sequelize model
it can be used to generate graphql input types