### PR TITLE
Default to an empty array if arguments is missing

### DIFF
--- a/src/simplifyAST.js
+++ b/src/simplifyAST.js
@@ -102,7 +102,7 @@ module.exports = function simplifyAST(ast, info, parent) {
       simpleAST.fields[key].key = name;
     }
 
-    simpleAST.fields[key].args = selection.arguments.reduce(function (args, arg) {
+    simpleAST.fields[key].args = (selection.arguments || []).reduce(function (args, arg) {
       args[arg.name.value] = simplifyValue(arg.value, info);
       return args;
     }, {});


### PR DESCRIPTION
In my use case, during server side rendering, some how the Apollo client is not returning an AST with `arguments` for `__typename` field. This lead to a crash for me, where the program is invoking `reduce()` on an `undefined` value.