### PR TITLE
Ignore docker configs and git pre-commit hook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,10 @@ node_modules
 src
 test
 scripts
+
+# Docker/tests
+Dockerfile
+docker-compose.yml
+
+# Git
+pre-commit


### PR DESCRIPTION
While debugging package installation issues I noticed that there were some things not in `.npmignore` that should probably be added:

```
Dockerfile
docker-compose.yml
pre-commit
```