### PR TITLE
Bump graphql-relay for GraphQL v14 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2201,10 +2201,13 @@
       }
     },
     "graphql-relay": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.5.5.tgz",
-      "integrity": "sha1-1oFebt1hjoeNXZIcE/xmAz7IZ+I=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",
+      "integrity": "sha512-OVDi6C9/qOT542Q3KxZdXja3NrDvqzbihn1B44PH8P/c5s0Q90RyQwT6guhGqXqbYEH6zbeLJWjQqiYvcg2vVw==",
+      "dev": true,
+      "requires": {
+        "prettier": "^1.16.0"
+      }
     },
     "growl": {
       "version": "1.9.2",
@@ -3917,6 +3920,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true,
       "optional": true
+    },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14",
-    "graphql-relay": "^0.4.2 || ^0.5.0",
+    "graphql-relay": "^0.4.2 || ^0.5.0 || ^0.6.0",
     "sequelize": ">=3.0.0"
   },
   "devDependencies": {
@@ -61,7 +61,7 @@
     "chai-as-promised": "^5.1.0",
     "eslint": "^1.7.3",
     "graphql": "^0.13.0",
-    "graphql-relay": "^0.5.0",
+    "graphql-relay": "^0.6.0",
     "isparta": "^4.0.0",
     "istanbul": "^0.4.0",
     "mocha": "^3.0.1",


### PR DESCRIPTION
`graphql-relay` didn't support GraphQL v14.x until [v0.6.0](https://github.com/graphql/graphql-relay-js/commit/da2801ab9e64006b1e41bcdb28c889799ee5c170#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).

To note: failed test seems to exist on master.