### PR TITLE
fix: add default scope order

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -86,7 +86,7 @@ function resolverFactory(targetMaybeThunk, options = {}) {
       }
 
       if (list && !findOptions.order) {
-        findOptions.order = [[model.primaryKeyAttribute, 'ASC']];
+        findOptions.order = model._scope.order || [[model.primaryKeyAttribute, 'ASC']];
       }
 
       if (association) {


### PR DESCRIPTION
Current behavior override the defaultScope order, this commit fix by taking the defaultScope order first then add the default order by id.

Closed #488