### PR TITLE
Support for latest sequelize version

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -57,7 +57,7 @@ export function idFetcher(sequelize, nodeTypeMapper) {
 
     const model = Object.keys(sequelize.models).find(model => model === type);
     if (model) {
-      return sequelize.models[model].findById(id);
+      return sequelize.models[model].findByPk(id);
     }
 
     if (nodeType) {


### PR DESCRIPTION
node query with latest sequelize version results in `sequelize.models[model].findById is not a function` error.

This pr fixes it.