### PR TITLE
Update relay.js

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -57,7 +57,14 @@ export function idFetcher(sequelize, nodeTypeMapper) {
 
     const model = Object.keys(sequelize.models).find(model => model === type);
     if (model) {
-      return sequelize.models[model].findById(id);
+      if (sequelize.models[model].findByPk)
+      {
+        return sequelize.models[model].findByPk(id);
+      }
+      else
+      {
+        return sequelize.models[model].findById(id);
+      }
     }
 
     if (nodeType) {


### PR DESCRIPTION
Support for latest Sequelize's Model.findByPk(id) with back compatibility.